### PR TITLE
fix: swagger annotation

### DIFF
--- a/api/dms/service/v1/license.go
+++ b/api/dms/service/v1/license.go
@@ -47,3 +47,10 @@ type CheckLicenseReq struct {
 	// swagger:file
 	LicenseFile *bytes.Buffer `json:"license_file"`
 }
+
+// swagger:response GetLicenseInfoReply
+type GetLicenseInfoReply struct {
+	// swagger:file
+	// in:  body
+	File []byte
+}

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -339,7 +339,13 @@
         "operationId": "GetLicenseInfo",
         "responses": {
           "200": {
-            "$ref": "#/responses/file"
+            "$ref": "#/responses/GetLicenseInfoReply"
+          },
+          "default": {
+            "description": "GenericResp",
+            "schema": {
+              "$ref": "#/definitions/GenericResp"
+            }
           }
         }
       }
@@ -6144,7 +6150,7 @@
           "x-go-name": "Uid"
         }
       },
-      "x-go-package": "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
+      "x-go-package": "github.com/actiontech/dms/api/dms/service/v1"
     },
     "UpdateCompanyNotice": {
       "description": "A companynotice",
@@ -6735,6 +6741,12 @@
           "type": "string",
           "description": "message"
         }
+      }
+    },
+    "GetLicenseInfoReply": {
+      "description": "",
+      "schema": {
+        "type": "file"
       }
     },
     "GetStaticLogoReply": {

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2465,7 +2465,7 @@ definitions:
                 type: string
                 x-go-name: Uid
         type: object
-        x-go-package: github.com/actiontech/dms/pkg/dms-common/api/dms/v1
+        x-go-package: github.com/actiontech/dms/api/dms/service/v1
     UpdateCompanyNotice:
         description: A companynotice
         properties:
@@ -3114,7 +3114,11 @@ paths:
             operationId: GetLicenseInfo
             responses:
                 "200":
-                    $ref: '#/responses/file'
+                    $ref: '#/responses/GetLicenseInfoReply'
+                default:
+                    description: GenericResp
+                    schema:
+                        $ref: '#/definitions/GenericResp'
             summary: get generate license info.
             tags:
                 - dms
@@ -4978,6 +4982,10 @@ responses:
             message:
                 description: message
                 type: string
+    GetLicenseInfoReply:
+        description: ""
+        schema:
+            type: file
     GetStaticLogoReply:
         description: ""
         schema:

--- a/internal/apiserver/service/dms_controller.go
+++ b/internal/apiserver/service/dms_controller.go
@@ -1839,7 +1839,8 @@ const (
 // get generate license info.
 //
 //	responses:
-//	  200: file
+//	  200: GetLicenseInfoReply
+//	  default: body:GenericResp
 func (d *DMSController) GetLicenseInfo(c echo.Context) error {
 	data, err := d.DMS.GetLicenseInfo(c.Request().Context())
 	if err != nil {


### PR DESCRIPTION
执行命令 make validation_swag 报错

The swagger spec at "/source/api/swagger.json" is invalid against swagger specification 2.0.
See errors below:
- some references could not be resolved in spec. First found: object has no key "file"
- could not resolve reference in /v1/dms/configurations/license/info to $ref #/responses/file: object has no key "file"

Makefile:74: recipe for target 'validation_swag' failed

