### PR TITLE
fix:  the connectivity test failed due to test all proxy target

### DIFF
--- a/internal/dms/biz/db_service.go
+++ b/internal/dms/biz/db_service.go
@@ -442,7 +442,7 @@ type IsConnectableReply struct {
 }
 
 func (d *DBServiceUsecase) IsConnectable(ctx context.Context, params dmsCommonV1.CheckDbConnectable) ([]*IsConnectableReply, error) {
-	dmsProxyTargets, err := d.dmsProxyTargetRepo.ListProxyTargets(ctx)
+	dmsProxyTargets, err := d.dmsProxyTargetRepo.ListProxyTargetsByScenario(ctx, ProxyScenarioCheckDbConn)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dms/biz/db_service.go
+++ b/internal/dms/biz/db_service.go
@@ -442,7 +442,7 @@ type IsConnectableReply struct {
 }
 
 func (d *DBServiceUsecase) IsConnectable(ctx context.Context, params dmsCommonV1.CheckDbConnectable) ([]*IsConnectableReply, error) {
-	dmsProxyTargets, err := d.dmsProxyTargetRepo.ListProxyTargetsByScenario(ctx, ProxyScenarioCheckDbConn)
+	dmsProxyTargets, err := d.dmsProxyTargetRepo.ListProxyTargetsByScenario(ctx, ProxyScenarioInternalService)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dms/biz/db_service.go
+++ b/internal/dms/biz/db_service.go
@@ -442,7 +442,7 @@ type IsConnectableReply struct {
 }
 
 func (d *DBServiceUsecase) IsConnectable(ctx context.Context, params dmsCommonV1.CheckDbConnectable) ([]*IsConnectableReply, error) {
-	dmsProxyTargets, err := d.dmsProxyTargetRepo.ListProxyTargetsByScenario(ctx, ProxyScenarioInternalService)
+	dmsProxyTargets, err := d.dmsProxyTargetRepo.ListProxyTargetsByScenarios(ctx, []ProxyScenario{ProxyScenarioInternalService})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/dms/biz/proxy.go
+++ b/internal/dms/biz/proxy.go
@@ -30,7 +30,7 @@ type ProxyTarget struct {
 type ProxyScenario string
 
 const (
-	ProxyScenarioCheckDbConn         ProxyScenario = "check_db_conn"
+	ProxyScenarioInternalService     ProxyScenario = "internal_service"
 	ProxyScenarioThirdPartyIntegrate ProxyScenario = "thrid_party_integrate"
 	ProxyScenarioUnknown             ProxyScenario = "unknown"
 )

--- a/internal/dms/biz/proxy.go
+++ b/internal/dms/biz/proxy.go
@@ -18,7 +18,7 @@ type ProxyTargetRepo interface {
 	SaveProxyTarget(ctx context.Context, u *ProxyTarget) error
 	UpdateProxyTarget(ctx context.Context, u *ProxyTarget) error
 	ListProxyTargets(ctx context.Context) ([]*ProxyTarget, error)
-	ListProxyTargetsByScenario(ctx context.Context, scenario ProxyScenario) ([]*ProxyTarget, error)
+	ListProxyTargetsByScenarios(ctx context.Context, scenarios []ProxyScenario) ([]*ProxyTarget, error)
 	GetProxyTargetByName(ctx context.Context, name string) (*ProxyTarget, error)
 }
 

--- a/internal/dms/service/proxy.go
+++ b/internal/dms/service/proxy.go
@@ -14,14 +14,32 @@ func (d *DMSService) RegisterDMSProxyTarget(ctx context.Context, currentUserUid 
 	defer func() {
 		d.log.Infof("RegisterDMSProxyTarget.req=%v;error=%v", req, err)
 	}()
-
+	scenairo, err := convertProxyScenario(req.DMSProxyTarget.Scenario)
+	if err != nil {
+		return err
+	}
 	if err := d.DmsProxyUsecase.RegisterDMSProxyTarget(ctx, currentUserUid, biz.RegisterDMSProxyTargetArgs{
 		Name:            req.DMSProxyTarget.Name,
 		Addr:            req.DMSProxyTarget.Addr,
 		Version:         req.DMSProxyTarget.Version,
 		ProxyUrlPrefixs: req.DMSProxyTarget.ProxyUrlPrefixs,
+		Scenario:        scenairo,
 	}); err != nil {
 		return fmt.Errorf("register dms proxy target failed: %v", err)
 	}
 	return nil
+}
+
+func convertProxyScenario(scenario dmsV1.ProxyScenario) (biz.ProxyScenario, error) {
+	switch scenario {
+	case dmsV1.ProxyScenarioCheckDbConn:
+		return biz.ProxyScenarioCheckDbConn, nil
+	case dmsV1.ProxyScenarioThirdPartyIntegrate:
+		return biz.ProxyScenarioThirdPartyIntegrate, nil
+	case "":
+		// 兼容旧版本SQLE
+		return biz.ProxyScenarioCheckDbConn, nil
+	default:
+		return "", biz.ErrUnknownProxyScenario
+	}
 }

--- a/internal/dms/service/proxy.go
+++ b/internal/dms/service/proxy.go
@@ -32,13 +32,13 @@ func (d *DMSService) RegisterDMSProxyTarget(ctx context.Context, currentUserUid 
 
 func convertProxyScenario(scenario dmsV1.ProxyScenario) (biz.ProxyScenario, error) {
 	switch scenario {
-	case dmsV1.ProxyScenarioCheckDbConn:
-		return biz.ProxyScenarioCheckDbConn, nil
+	case dmsV1.ProxyScenarioInternalService:
+		return biz.ProxyScenarioInternalService, nil
 	case dmsV1.ProxyScenarioThirdPartyIntegrate:
 		return biz.ProxyScenarioThirdPartyIntegrate, nil
 	case "":
 		// 兼容旧版本SQLE
-		return biz.ProxyScenarioCheckDbConn, nil
+		return biz.ProxyScenarioInternalService, nil
 	default:
 		return "", biz.ErrUnknownProxyScenario
 	}

--- a/internal/dms/storage/convert.go
+++ b/internal/dms/storage/convert.go
@@ -552,12 +552,24 @@ func convertModelProjectStatus(status string) biz.ProjectStatus {
 	}
 }
 
+func convertModelProxyScenario(scenario string) biz.ProxyScenario {
+	switch scenario {
+	case "check_db_conn":
+		return biz.ProxyScenarioCheckDbConn
+	case "thrid_party_integrate":
+		return biz.ProxyScenarioThirdPartyIntegrate
+	default:
+		return biz.ProxyScenarioUnknown
+	}
+}
+
 func convertBizProxyTarget(t *biz.ProxyTarget) (*model.ProxyTarget, error) {
 	return &model.ProxyTarget{
 		Name:            t.Name,
 		Url:             t.URL.String(),
 		Version:         t.Version,
 		ProxyUrlPrefixs: strings.Join(t.GetProxyUrlPrefixs(), ";"),
+		Scenario:        string(t.Scenario),
 	}, nil
 }
 
@@ -572,7 +584,8 @@ func convertModelProxyTarget(t *model.ProxyTarget) (*biz.ProxyTarget, error) {
 			URL:  url,
 			Meta: echo.Map{},
 		},
-		Version: t.Version,
+		Version:  t.Version,
+		Scenario: convertModelProxyScenario(t.Scenario),
 	}
 	p.SetProxyUrlPrefix(strings.Split(t.ProxyUrlPrefixs, ";"))
 	return p, nil

--- a/internal/dms/storage/convert.go
+++ b/internal/dms/storage/convert.go
@@ -554,8 +554,8 @@ func convertModelProjectStatus(status string) biz.ProjectStatus {
 
 func convertModelProxyScenario(scenario string) biz.ProxyScenario {
 	switch scenario {
-	case "check_db_conn":
-		return biz.ProxyScenarioCheckDbConn
+	case "internal_service":
+		return biz.ProxyScenarioInternalService
 	case "thrid_party_integrate":
 		return biz.ProxyScenarioThirdPartyIntegrate
 	default:

--- a/internal/dms/storage/model/model.go
+++ b/internal/dms/storage/model/model.go
@@ -192,11 +192,17 @@ type Project struct {
 	Status        string `gorm:"size:64;default:'active'"`
 }
 
+const (
+	ProxyScenarioCheckDbConn         string = "check_db_conn"
+	ProxyScenarioThirdPartyIntegrate string = "thrid_party_integrate"
+)
+
 type ProxyTarget struct {
 	Name            string `json:"name" gorm:"primaryKey;size:200;not null;column:name"`
 	Url             string `json:"url" gorm:"size:255;column:url"`
 	Version         string `json:"version" gorm:"size:64;column:version"`
 	ProxyUrlPrefixs string `json:"proxy_url_prefixs" gorm:"size:255;column:proxy_url_prefixs"`
+	Scenario        string `json:"scenario" gorm:"size:64;column:scenario;default:'check_db_conn'"`
 }
 
 type Plugin struct {

--- a/internal/dms/storage/model/model.go
+++ b/internal/dms/storage/model/model.go
@@ -193,7 +193,7 @@ type Project struct {
 }
 
 const (
-	ProxyScenarioCheckDbConn         string = "check_db_conn"
+	ProxyScenarioInternalService     string = "internal_service"
 	ProxyScenarioThirdPartyIntegrate string = "thrid_party_integrate"
 )
 
@@ -202,7 +202,7 @@ type ProxyTarget struct {
 	Url             string `json:"url" gorm:"size:255;column:url"`
 	Version         string `json:"version" gorm:"size:64;column:version"`
 	ProxyUrlPrefixs string `json:"proxy_url_prefixs" gorm:"size:255;column:proxy_url_prefixs"`
-	Scenario        string `json:"scenario" gorm:"size:64;column:scenario;default:'check_db_conn'"`
+	Scenario        string `json:"scenario" gorm:"size:64;column:scenario;default:'internal_service'"`
 }
 
 type Plugin struct {

--- a/internal/dms/storage/proxy.go
+++ b/internal/dms/storage/proxy.go
@@ -79,13 +79,13 @@ func (d *ProxyTargetRepo) CheckProxyTargetExist(ctx context.Context, targetNames
 	return true, nil
 }
 
-func (d *ProxyTargetRepo) ListProxyTargetsByScenario(ctx context.Context, scenario biz.ProxyScenario) (targets []*biz.ProxyTarget, err error) {
+func (d *ProxyTargetRepo) ListProxyTargetsByScenarios(ctx context.Context, scenarios []biz.ProxyScenario) (targets []*biz.ProxyTarget, err error) {
 
 	var models []*model.ProxyTarget
 	if err := transaction(d.log, ctx, d.db, func(tx *gorm.DB) error {
 
 		// find targets
-		if err := tx.WithContext(ctx).Where("scenario = ?", string(scenario)).Find(&models).Error; err != nil {
+		if err := tx.WithContext(ctx).Where("scenario IN (?)", scenarios).Find(&models).Error; err != nil {
 			return fmt.Errorf("failed to list proxy targets: %v", err)
 		}
 

--- a/internal/dms/storage/proxy.go
+++ b/internal/dms/storage/proxy.go
@@ -79,6 +79,32 @@ func (d *ProxyTargetRepo) CheckProxyTargetExist(ctx context.Context, targetNames
 	return true, nil
 }
 
+func (d *ProxyTargetRepo) ListProxyTargetsByScenario(ctx context.Context, scenario biz.ProxyScenario) (targets []*biz.ProxyTarget, err error) {
+
+	var models []*model.ProxyTarget
+	if err := transaction(d.log, ctx, d.db, func(tx *gorm.DB) error {
+
+		// find targets
+		if err := tx.WithContext(ctx).Where("scenario = ?", string(scenario)).Find(&models).Error; err != nil {
+			return fmt.Errorf("failed to list proxy targets: %v", err)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// convert model to biz
+	for _, model := range models {
+		t, err := convertModelProxyTarget(model)
+		if err != nil {
+			return nil, pkgErr.WrapStorageErr(d.log, fmt.Errorf("failed to convert model proxy targets: %v", err))
+		}
+		targets = append(targets, t)
+	}
+	return targets, nil
+}
+
 func (d *ProxyTargetRepo) ListProxyTargets(ctx context.Context) (targets []*biz.ProxyTarget, err error) {
 
 	var models []*model.ProxyTarget

--- a/pkg/dms-common/api/dms/v1/proxy.go
+++ b/pkg/dms-common/api/dms/v1/proxy.go
@@ -31,7 +31,7 @@ type DMSProxyTarget struct {
 type ProxyScenario string
 
 const (
-	ProxyScenarioCheckDbConn         ProxyScenario = "check_db_conn"
+	ProxyScenarioInternalService     ProxyScenario = "internal_service"
 	ProxyScenarioThirdPartyIntegrate ProxyScenario = "thrid_party_integrate"
 )
 

--- a/pkg/dms-common/api/dms/v1/proxy.go
+++ b/pkg/dms-common/api/dms/v1/proxy.go
@@ -23,7 +23,17 @@ type DMSProxyTarget struct {
 	// url prefix that need to be proxy, eg: /v1/user
 	// Required: true
 	ProxyUrlPrefixs []string `json:"proxy_url_prefixs" validate:"required"`
+	// the scenario is used to differentiate scenarios
+	Scenario ProxyScenario `json:"scenario"`
 }
+
+// swagger:enum ProxyScenario
+type ProxyScenario string
+
+const (
+	ProxyScenarioCheckDbConn         ProxyScenario = "check_db_conn"
+	ProxyScenarioThirdPartyIntegrate ProxyScenario = "thrid_party_integrate"
+)
 
 // swagger:model RegisterDMSProxyTargetReply
 type RegisterDMSProxyTargetReply struct {

--- a/pkg/dms-common/register/register.go
+++ b/pkg/dms-common/register/register.go
@@ -9,8 +9,8 @@ import (
 )
 
 // RegisterDMSProxyTarget 向DMS注册反向代理，将proxyPrefix开头的请求转发到自身服务
-// eg: name = sqle; url = http://10.1.2.1:5432; proxyPrefix = /v1/sqle 表示要求DMS将/v1/sqle开头的请求转发到sqle服务所在地址 http://10.1.2.1:5432
-func RegisterDMSProxyTarget(ctx context.Context, dmsAddr, targetName, targetAddr, version string, proxyUrlPrefixs []string) error {
+// eg: name = sqle; url = http://10.1.2.1:5432; proxyPrefix = /v1/sqle 表示要求DMS将/v1/sqle开头的请求转发到sqle服务所在地址 http://10.1.2.1:5432 scenario选择代理转发的使用场景，例如：ProxyScenarioCheckDbConn，会用于测试数据库的连通性
+func RegisterDMSProxyTarget(ctx context.Context, dmsAddr, targetName, targetAddr, version string, proxyUrlPrefixs []string, scenario dmsV1.ProxyScenario) error {
 	header := map[string]string{
 		"Authorization": pkgHttp.DefaultDMSToken,
 	}
@@ -22,6 +22,7 @@ func RegisterDMSProxyTarget(ctx context.Context, dmsAddr, targetName, targetAddr
 			Addr:            targetAddr,
 			Version:         version,
 			ProxyUrlPrefixs: proxyUrlPrefixs,
+			Scenario:        scenario,
 		},
 	}
 

--- a/pkg/dms-common/register/register.go
+++ b/pkg/dms-common/register/register.go
@@ -9,7 +9,7 @@ import (
 )
 
 // RegisterDMSProxyTarget 向DMS注册反向代理，将proxyPrefix开头的请求转发到自身服务
-// eg: name = sqle; url = http://10.1.2.1:5432; proxyPrefix = /v1/sqle 表示要求DMS将/v1/sqle开头的请求转发到sqle服务所在地址 http://10.1.2.1:5432 scenario选择代理转发的使用场景，例如：ProxyScenarioCheckDbConn，会用于测试数据库的连通性
+// eg: name = sqle; url = http://10.1.2.1:5432; proxyPrefix = /v1/sqle 表示要求DMS将/v1/sqle开头的请求转发到sqle服务所在地址 http://10.1.2.1:5432 scenario选择代理转发的使用场景，例如：ProxyScenarioInternalService，会用于测试数据库的连通性
 func RegisterDMSProxyTarget(ctx context.Context, dmsAddr, targetName, targetAddr, version string, proxyUrlPrefixs []string, scenario dmsV1.ProxyScenario) error {
 	header := map[string]string{
 		"Authorization": pkgHttp.DefaultDMSToken,


### PR DESCRIPTION
#153 

1. add scenario field  to table `proxy_targets`, default value is "check_db_conn" in order to compatible with data from older versions of SQLE.
2. test data source connectivity, only test the proxy_target which scenario is "check_db_conn".
3. updated the interface for registering DMS.
4. updated the function for registering DMS.