### PR TITLE
#177 #wanghc #给postgresql链接一个默认数据库postgres（与插件一致）

### DIFF
--- a/internal/dms/biz/cloudbeaver.go
+++ b/internal/dms/biz/cloudbeaver.go
@@ -961,6 +961,7 @@ func (cu *CloudbeaverUsecase) fillMSSQLParams(config map[string]interface{}) err
 
 func (cu *CloudbeaverUsecase) fillPGSQLParams(config map[string]interface{}) error {
 	config["driverId"] = "postgresql:postgres-jdbc"
+	config["databaseName"] = "postgres"
 	config["providerProperties"] = map[string]interface{}{
 		"@dbeaver-show-non-default-db@": true,
 		"@dbeaver-show-unavailable-db@": true,


### PR DESCRIPTION
#177
actiontech/dms/issues/177
description：
dms创建postgresql数据源时没有指定数据库，cloudbeaver默认使用用户名当做数据库名连接数据库，导致新创用户无法找到库
dms创建连接时给定默认数据库 postgres