### PR TITLE
修改cloudbeaver驱动属性默认值

### DIFF
--- a/internal/dms/biz/cloudbeaver.go
+++ b/internal/dms/biz/cloudbeaver.go
@@ -1083,6 +1083,10 @@ func (cu *CloudbeaverUsecase) fillOracleParams(inst *DBService, config map[strin
 		"@dbeaver-sid-service@": "SID",
 		"oracle.logon-as":       "Normal",
 	}
+	// 默认关闭timezoneAsRegion，防止连接Oracle11g报错
+	config["properties"] = map[string]interface{}{
+		"oracle.jdbc.timezoneAsRegion": false,
+	}
 	return nil
 }
 


### PR DESCRIPTION
issue：actiontech/sqle/issues/1407
描述：默认关闭timezoneAsRegion，防止连接Oracle11g时报错