### PR TITLE
fix: swagger enum lose and swagger business definitions field lose fix

### DIFF
--- a/api/dms/service/v1/project.go
+++ b/api/dms/service/v1/project.go
@@ -71,10 +71,10 @@ type UpdateProject struct {
 	// is fixed business
 	IsFixedBusiness *bool `json:"is_fixed_business"`
 	// Project business
-	Business []Business `json:"business"`
+	Business []BusinessForUpdate `json:"business"`
 }
 
-type Business struct {
+type BusinessForUpdate struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -931,7 +931,7 @@
           {
             "type": "file",
             "description": "file upload",
-            "name": "formData",
+            "name": "file",
             "in": "formData"
           }
         ],
@@ -4958,6 +4958,24 @@
       "properties": {
         "id": {
           "type": "string",
+          "x-go-name": "Id"
+        },
+        "is_used": {
+          "type": "boolean",
+          "x-go-name": "IsUsed"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        }
+      },
+      "x-go-package": "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
+    },
+    "BusinessForUpdate": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
           "x-go-name": "ID"
         },
         "name": {
@@ -6375,14 +6393,15 @@
           "$ref": "#/definitions/AccessTokenInfo"
         },
         "authentication_type": {
-          "description": "user authentication type\nldap UserAuthenticationTypeLDAP\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
+          "description": "user authentication type\nldap UserAuthenticationTypeLDAP\ndms UserAuthenticationTypeDMS\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
           "type": "string",
           "enum": [
             "ldap",
+            "dms",
             "oauth2",
             "unknown"
           ],
-          "x-go-enum-desc": "ldap UserAuthenticationTypeLDAP\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
+          "x-go-enum-desc": "ldap UserAuthenticationTypeLDAP\ndms UserAuthenticationTypeDMS\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
           "x-go-name": "AuthenticationType"
         },
         "email": {
@@ -7983,14 +8002,15 @@
       "type": "object",
       "properties": {
         "authentication_type": {
-          "description": "user authentication type\nldap UserAuthenticationTypeLDAP\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
+          "description": "user authentication type\nldap UserAuthenticationTypeLDAP\ndms UserAuthenticationTypeDMS\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
           "type": "string",
           "enum": [
             "ldap",
+            "dms",
             "oauth2",
             "unknown"
           ],
-          "x-go-enum-desc": "ldap UserAuthenticationTypeLDAP\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
+          "x-go-enum-desc": "ldap UserAuthenticationTypeLDAP\ndms UserAuthenticationTypeDMS\noauth2 UserAuthenticationTypeOAUTH2\nunknown UserAuthenticationTypeUnknown",
           "x-go-name": "AuthenticationType"
         },
         "email": {
@@ -9095,7 +9115,7 @@
           "x-go-name": "Uid"
         }
       },
-      "x-go-package": "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
+      "x-go-package": "github.com/actiontech/dms/api/dms/service/v1"
     },
     "UpdateCompanyNotice": {
       "description": "A companynotice",
@@ -9389,7 +9409,7 @@
           "description": "Project business",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Business"
+            "$ref": "#/definitions/BusinessForUpdate"
           },
           "x-go-name": "Business"
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -477,6 +477,19 @@ definitions:
         properties:
             id:
                 type: string
+                x-go-name: Id
+            is_used:
+                type: boolean
+                x-go-name: IsUsed
+            name:
+                type: string
+                x-go-name: Name
+        type: object
+        x-go-package: github.com/actiontech/dms/pkg/dms-common/api/dms/v1
+    BusinessForUpdate:
+        properties:
+            id:
+                type: string
                 x-go-name: ID
             name:
                 type: string
@@ -1566,15 +1579,18 @@ definitions:
                 description: |-
                     user authentication type
                     ldap UserAuthenticationTypeLDAP
+                    dms UserAuthenticationTypeDMS
                     oauth2 UserAuthenticationTypeOAUTH2
                     unknown UserAuthenticationTypeUnknown
                 enum:
                     - ldap
+                    - dms
                     - oauth2
                     - unknown
                 type: string
                 x-go-enum-desc: |-
                     ldap UserAuthenticationTypeLDAP
+                    dms UserAuthenticationTypeDMS
                     oauth2 UserAuthenticationTypeOAUTH2
                     unknown UserAuthenticationTypeUnknown
                 x-go-name: AuthenticationType
@@ -2829,15 +2845,18 @@ definitions:
                 description: |-
                     user authentication type
                     ldap UserAuthenticationTypeLDAP
+                    dms UserAuthenticationTypeDMS
                     oauth2 UserAuthenticationTypeOAUTH2
                     unknown UserAuthenticationTypeUnknown
                 enum:
                     - ldap
+                    - dms
                     - oauth2
                     - unknown
                 type: string
                 x-go-enum-desc: |-
                     ldap UserAuthenticationTypeLDAP
+                    dms UserAuthenticationTypeDMS
                     oauth2 UserAuthenticationTypeOAUTH2
                     unknown UserAuthenticationTypeUnknown
                 x-go-name: AuthenticationType
@@ -3735,7 +3754,7 @@ definitions:
                 type: string
                 x-go-name: Uid
         type: object
-        x-go-package: github.com/actiontech/dms/pkg/dms-common/api/dms/v1
+        x-go-package: github.com/actiontech/dms/api/dms/service/v1
     UpdateCompanyNotice:
         description: A companynotice
         properties:
@@ -3951,7 +3970,7 @@ definitions:
             business:
                 description: Project business
                 items:
-                    $ref: '#/definitions/Business'
+                    $ref: '#/definitions/BusinessForUpdate'
                 type: array
                 x-go-name: Business
             desc:
@@ -4967,7 +4986,7 @@ paths:
                   type: string
                 - description: file upload
                   in: formData
-                  name: formData
+                  name: file
                   type: file
             responses:
                 "200":

--- a/internal/apiserver/service/dms_controller.go
+++ b/internal/apiserver/service/dms_controller.go
@@ -593,7 +593,7 @@ func (d *DMSController) GetStaticLogo(c echo.Context) error {
 //     in: formData
 //     required: false
 //     type: string
-//   - name: formData
+//   - name: file
 //     description: file upload
 //     in: formData
 //     required: false

--- a/internal/dms/biz/project_ce.go
+++ b/internal/dms/biz/project_ce.go
@@ -53,7 +53,7 @@ func (d *ProjectUsecase) PreviewImportProjects(ctx context.Context, uid, file st
 	return nil, errNotSupportProject
 }
 
-func (d *ProjectUsecase) UpdateProject(ctx context.Context, currentUserUid, projectUid string, desc *string, isFixBusiness *bool, business []v1.Business) (err error) {
+func (d *ProjectUsecase) UpdateProject(ctx context.Context, currentUserUid, projectUid string, desc *string, isFixBusiness *bool, business []v1.BusinessForUpdate) (err error) {
 	return errNotSupportProject
 }
 

--- a/pkg/dms-common/api/dms/v1/user.go
+++ b/pkg/dms-common/api/dms/v1/user.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	base "github.com/actiontech/dms/pkg/dms-common/api/base/v1"
-	_const "github.com/actiontech/dms/pkg/dms-common/pkg/const"
 )
 
 // swagger:parameters GetUser
@@ -73,9 +72,9 @@ type UidWithName struct {
 type UserAuthenticationType string
 
 const (
-	UserAuthenticationTypeLDAP    UserAuthenticationType = "ldap"                  // user verify through ldap
-	UserAuthenticationTypeDMS     UserAuthenticationType = _const.DmsComponentName // user verify through dms
-	UserAuthenticationTypeOAUTH2  UserAuthenticationType = "oauth2"                // user verify through oauth2
+	UserAuthenticationTypeLDAP    UserAuthenticationType = "ldap"   // user verify through ldap
+	UserAuthenticationTypeDMS     UserAuthenticationType = "dms"    // user verify through dms
+	UserAuthenticationTypeOAUTH2  UserAuthenticationType = "oauth2" // user verify through oauth2
 	UserAuthenticationTypeUnknown UserAuthenticationType = "unknown"
 )
 


### PR DESCRIPTION
关联issue：https://github.com/actiontech/dms/issues/269  
描述：
1、接口结构体名称重复，导致接口定义不符合预期修复
2、swagger name名称修改
3、swagger枚举值缺失修复