### PR TITLE
dms add https support

### DIFF
--- a/internal/apiserver/service/service.go
+++ b/internal/apiserver/service/service.go
@@ -86,10 +86,24 @@ func (s *APIServer) RunHttpServer(logger utilLog.Logger) error {
 	if err := s.initRouter(); nil != err {
 		return fmt.Errorf("failed to init router: %v", err)
 	}
-
-	if err := s.echo.Start(s.opts.GetAPIServer().GetHTTPAddr()); nil != err {
-		if err != http.ErrServerClosed {
-			return fmt.Errorf("failed to run http server: %v", err)
+	if s.opts.APIServiceOpts.EnableHttps {
+		if s.opts.APIServiceOpts.CertFilePath == "" || s.opts.APIServiceOpts.KeyFilePath == "" {
+			return fmt.Errorf("cert file path and key file path are required on https mode")
+		}
+		if err := s.echo.StartTLS(
+			s.opts.GetAPIServer().GetHTTPAddr(),
+			s.opts.APIServiceOpts.CertFilePath,
+			s.opts.APIServiceOpts.KeyFilePath,
+		); err != nil {
+			if err != http.ErrServerClosed {
+				return fmt.Errorf("failed to run https server: %v", err)
+			}
+		}
+	} else {
+		if err := s.echo.Start(s.opts.GetAPIServer().GetHTTPAddr()); nil != err {
+			if err != http.ErrServerClosed {
+				return fmt.Errorf("failed to run http server: %v", err)
+			}
 		}
 	}
 	return nil

--- a/internal/dms/service/service.go
+++ b/internal/dms/service/service.go
@@ -96,7 +96,7 @@ func NewAndInitDMSService(logger utilLog.Logger, opts *conf.DMSOptions) (*DMSSer
 	memberUsecase = *biz.NewMemberUsecase(logger, tx, memberRepo, userUsecase, roleUsecase, dbServiceUseCase, opPermissionVerifyUsecase, projectUsecase)
 	memberGroupRepo := storage.NewMemberGroupRepo(logger, st)
 	memberGroupUsecase := biz.NewMemberGroupUsecase(logger, tx, memberGroupRepo, userUsecase, roleUsecase, dbServiceUseCase, opPermissionVerifyUsecase, projectUsecase, &memberUsecase)
-	dmsProxyUsecase, err := biz.NewDmsProxyUsecase(logger, dmsProxyTargetRepo, opts.APIServiceOpts.Port, opPermissionUsecase, roleUsecase)
+	dmsProxyUsecase, err := biz.NewDmsProxyUsecase(logger, dmsProxyTargetRepo, opts.APIServiceOpts, opPermissionUsecase, roleUsecase)
 	if err != nil {
 		return nil, fmt.Errorf("failed to new dms proxy usecase: %v", err)
 	}


### PR DESCRIPTION
issue：https://github.com/actiontech/dms/issues/340
测试：https://github.com/actiontech/dms/issues/340#issuecomment-2700497452
影响面分析：https://github.com/actiontech/dms/issues/340#issuecomment-2700188520
变更：
1. 根据DMS配置判定是否开启https
2. 对于DMS中（自引用）没有支持HTTPs的调用函数，根据DMS的https开启状况修改URL的Scheme