### PR TITLE
fix: remove env SQLE_JAVA_HOME

### DIFF
--- a/build/dms_sqle_provision.spec
+++ b/build/dms_sqle_provision.spec
@@ -116,25 +116,12 @@ dbms.default_listen_address=0.0.0.0
 EOF
 
 #service
-# 检查 .bashrc 文件是否存在
-if [ -f ~/.bashrc ]; then
-    if grep -q "^export SQLE_JAVA_HOME=" ~/.bashrc; then
-        # 如果 SQLE_JAVA_HOME 已经存在,则更新其值
-        sed -i "s|^export SQLE_JAVA_HOME=.*|export SQLE_JAVA_HOME=$RPM_INSTALL_PREFIX/jdk|" ~/.bashrc
-    else
-        echo "export SQLE_JAVA_HOME=$RPM_INSTALL_PREFIX/jdk" >> ~/.bashrc
-    fi
-else
-    echo "warn: .bashrc file not found."
-fi
-source ~/.bashrc
 grep systemd /proc/1/comm 1>/dev/null 2>&1
 if [ $? -eq 0 ]; then
     sed -e "s|PIDFile=|PIDFile=$RPM_INSTALL_PREFIX\/sqled.pid|g" \
     -e "s|User=|User=actiontech-universe|g" \
     -e "s|ExecStart=|ExecStart=/bin/sh -c 'exec $RPM_INSTALL_PREFIX\/bin\/sqled --config $RPM_INSTALL_PREFIX\/etc\/config.yaml --pidfile=$RPM_INSTALL_PREFIX\/sqled.pid >>$RPM_INSTALL_PREFIX\/std.log 2>\&1'|g" \
     -e "s|WorkingDirectory=|WorkingDirectory=$RPM_INSTALL_PREFIX|g" \
-    -e "s|Environment=|Environment=SQLE_JAVA_HOME=$RPM_INSTALL_PREFIX\/jdk|g" \
     $RPM_INSTALL_PREFIX/scripts/sqled.systemd > /lib/systemd/system/sqled.service
     sed -e "s|PIDFile=|PIDFile=$RPM_INSTALL_PREFIX\/dms.pid|g" \
     -e "s|User=|User=actiontech-universe|g" \
@@ -146,7 +133,7 @@ if [ $? -eq 0 ]; then
     -e "s|WorkingDirectory=|WorkingDirectory=$RPM_INSTALL_PREFIX|g" \
     $RPM_INSTALL_PREFIX/scripts/provision.systemd > /lib/systemd/system/provision.service
     sed -e "s|PIDFile=|PIDFile=$RPM_INSTALL_PREFIX\/neo4j-community/run/neo4j.pid|g" \
-    -e "s|ExecStart=|ExecStart=/bin/bash -c 'export JAVA_HOME=$SQLE_JAVA_HOME\;\ $RPM_INSTALL_PREFIX\/neo4j-community/bin/neo4j start'|g" \
+    -e "s|ExecStart=|ExecStart=/bin/bash -c 'export JAVA_HOME=$RPM_INSTALL_PREFIX/jdk\;\ $RPM_INSTALL_PREFIX\/neo4j-community/bin/neo4j start'|g" \
     -e "s|ExecStop=|ExecStop=$RPM_INSTALL_PREFIX\/neo4j-community/bin/neo4j stop|g" \
     -e "s|ExecReload=|ExecReload=$RPM_INSTALL_PREFIX\/neo4j-community/bin/neo4j restart|g" \
     -e "s|WorkingDirectory=|WorkingDirectory=$RPM_INSTALL_PREFIX/neo4j-community|g" \


### PR DESCRIPTION
### **User description**
issue: https://github.com/actiontech/sqle/pull/2995
link https://github.com/actiontech/sqle/pull/2995


___

### **Description**
- 删除 `.bashrc` 中对 `SQLE_JAVA_HOME` 的配置

- 直接在 systemd 服务文件中设置 `JAVA_HOME`

- 优化 systemd 服务配置脚本


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dms_sqle_provision.spec</strong><dd><code>优化 `build/dms_sqle_provision.spec` 中的 JAVA_HOME 设置</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build/dms_sqle_provision.spec

<li>删除 <code>.bashrc</code> 中关于 <code>SQLE_JAVA_HOME</code> 的设置<br> <li> 在 systemd 服务文件中直接设置 <code>JAVA_HOME</code> 为 <code>$RPM_INSTALL_PREFIX/jdk</code><br> <li> 更新 systemd 服务配置以反映更改


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/401/files#diff-dd8e923ce458e1d6058475e661a7bfe3e4e6f7f5030d91450beae04f951b0cfe">+1/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>