### PR TITLE
fix: wrong cloudbeaver path causing redirection to root path

### DIFF
--- a/internal/dms/service/cloudbeaver.go
+++ b/internal/dms/service/cloudbeaver.go
@@ -102,7 +102,7 @@ func (cs *CloudbeaverService) GetCloudbeaverConfiguration(ctx context.Context) (
 			SQLQueryRootURI string `json:"sql_query_root_uri"`
 		}{
 			EnableSQLQuery:  cs.CloudbeaverUsecase.IsCloudbeaverConfigured(),
-			SQLQueryRootURI: cs.CloudbeaverUsecase.GetRootUri() + "/",
+			SQLQueryRootURI: cs.CloudbeaverUsecase.GetRootUri() + "/", // 确保URL以斜杠结尾，防止DMS开启HTTPS时，Web服务器重定向到HTTP根路径导致访问错误
 		},
 	}, nil
 }

--- a/internal/dms/service/cloudbeaver.go
+++ b/internal/dms/service/cloudbeaver.go
@@ -80,7 +80,6 @@ func NewAndInitCloudbeaverService(logger utilLog.Logger, opts *conf.DMSOptions) 
 		}
 	}
 
-
 	cloudbeaverUsecase := biz.NewCloudbeaverUsecase(logger, cfg, userUsecase, dbServiceUseCase, opPermissionVerifyUsecase, dmsConfigUseCase, dataMaskingUsecase, cloudbeaverRepo, dmsProxyTargetRepo, cbOperationLogUsecase, projectUsecase)
 	proxyUsecase := biz.NewCloudbeaverProxyUsecase(logger, cloudbeaverUsecase)
 
@@ -103,7 +102,7 @@ func (cs *CloudbeaverService) GetCloudbeaverConfiguration(ctx context.Context) (
 			SQLQueryRootURI string `json:"sql_query_root_uri"`
 		}{
 			EnableSQLQuery:  cs.CloudbeaverUsecase.IsCloudbeaverConfigured(),
-			SQLQueryRootURI: cs.CloudbeaverUsecase.GetRootUri(),
+			SQLQueryRootURI: cs.CloudbeaverUsecase.GetRootUri() + "/",
 		},
 	}, nil
 }


### PR DESCRIPTION
### **User description**
issue https://github.com/actiontech/dms/issues/340
改动内容：返回给前端的cloudbeaver的路由增加斜杠
改动原因：
1. 之前的路由缺少斜杠，会导致前端重定向到跟路由，在http开启的情况下和cloudbeaver的路由一致。
2. 但是开启https后，没有增加斜杠的路由会让web server依然重定向到http的跟路由（从https降级到http），导致使用错误的schema访问dms。访问失败。
3. 因此需要增加一个斜杠，让web server正确地跳转到cloudbeaver


___

### **Description**
- 修复配置文件中启用 HTTPS 时未生效的问题

- 在 `SQLQueryRootURI` 添加尾部斜杠，防止重定向错误


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudbeaver.go</strong><dd><code>Append trailing slash to fix HTTPS redirection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/service/cloudbeaver.go

<li>Append trailing slash to <code>SQLQueryRootURI</code> in configuration<br> <li> Remove unnecessary blank line in <code>NewAndInitCloudbeaverService</code> function


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/404/files#diff-2c018a749d0e87ae954e73ec48386a6d9f95e8d47b54d4e8f3d87288e5cac24f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>