### PR TITLE
add: add environmentTagUsecase to DBServiceSyncTaskUsecase for sync o…

### DIFF
--- a/internal/dms/biz/db_service_sync_task.go
+++ b/internal/dms/biz/db_service_sync_task.go
@@ -26,17 +26,20 @@ type DBServiceSyncTaskUsecase struct {
 	opPermissionVerifyUsecase *OpPermissionVerifyUsecase
 	dbServiceUsecase          *DBServiceUsecase
 	projectUsecase            *ProjectUsecase
+	environmentTagUsecase     *EnvironmentTagUsecase
 	cron                      *cron.Cron
 	lastSyncTime              time.Time
 }
 
-func NewDBServiceSyncTaskUsecase(log utilLog.Logger, repo DBServiceSyncTaskRepo, opPermissionVerifyUsecase *OpPermissionVerifyUsecase, projectUsecase *ProjectUsecase, dbServiceUsecase *DBServiceUsecase) *DBServiceSyncTaskUsecase {
+func NewDBServiceSyncTaskUsecase(log utilLog.Logger, repo DBServiceSyncTaskRepo, opPermissionVerifyUsecase *OpPermissionVerifyUsecase,
+	projectUsecase *ProjectUsecase, dbServiceUsecase *DBServiceUsecase, environmentTagUsecase *EnvironmentTagUsecase) *DBServiceSyncTaskUsecase {
 	return &DBServiceSyncTaskUsecase{
 		log:                       utilLog.NewHelper(log, utilLog.WithMessageKey("biz.db_service_sync_task")),
 		repo:                      repo,
 		opPermissionVerifyUsecase: opPermissionVerifyUsecase,
 		projectUsecase:            projectUsecase,
 		dbServiceUsecase:          dbServiceUsecase,
+		environmentTagUsecase:     environmentTagUsecase,
 	}
 }
 

--- a/internal/dms/service/service.go
+++ b/internal/dms/service/service.go
@@ -81,7 +81,7 @@ func NewAndInitDMSService(logger utilLog.Logger, opts *conf.DMSOptions) (*DMSSer
 	dmsProxyTargetRepo := storage.NewProxyTargetRepo(logger, st)
 	dbServiceUseCase := biz.NewDBServiceUsecase(logger, dbServiceRepo, pluginUseCase, opPermissionVerifyUsecase, projectUsecase, dmsProxyTargetRepo, &environmentTagUsecase)
 	dbServiceTaskRepo := storage.NewDBServiceSyncTaskRepo(logger, st)
-	dbServiceTaskUsecase := biz.NewDBServiceSyncTaskUsecase(logger, dbServiceTaskRepo, opPermissionVerifyUsecase, projectUsecase, dbServiceUseCase)
+	dbServiceTaskUsecase := biz.NewDBServiceSyncTaskUsecase(logger, dbServiceTaskRepo, opPermissionVerifyUsecase, projectUsecase, dbServiceUseCase, &environmentTagUsecase)
 	ldapConfigurationRepo := storage.NewLDAPConfigurationRepo(logger, st)
 	ldapConfigurationUsecase := biz.NewLDAPConfigurationUsecase(logger, tx, ldapConfigurationRepo)
 	userRepo := storage.NewUserRepo(logger, st)


### PR DESCRIPTION
issue： https://github.com/actiontech/sqle/issues/3008

同步外部数据源补充environment tag usecase，用以实现在同步外部数据源时添加环境标签