### PR TITLE
feat(router): temporarily restore v1 interfaces for DB services and projects

### DIFF
--- a/internal/apiserver/service/router.go
+++ b/internal/apiserver/service/router.go
@@ -51,7 +51,7 @@ func (s *APIServer) initRouter() error {
 		dbServiceV1 := v1.Group(dmsV1.DBServiceRouterGroup)
 		{
 			dbServiceV1.POST("", s.DeprecatedBy(dmsV2.GroupV2))
-			dbServiceV1.GET("", s.DeprecatedBy(dmsV2.GroupV2))
+			dbServiceV1.GET("", s.DMSController.ListDBServicesV2) // 兼容jet brain插件，临时开放v1接口
 			dbServiceV1.GET("/tips", s.DMSController.ListDBServiceTips)
 			dbServiceV1.DELETE("/:db_service_uid", s.DMSController.DelDBService)
 			dbServiceV1.PUT("/:db_service_uid", s.DeprecatedBy(dmsV2.GroupV2))
@@ -133,7 +133,7 @@ func (s *APIServer) initRouter() error {
 		opPermissionV1.GET("", s.DMSController.ListOpPermissions)
 
 		projectV1 := v1.Group(dmsV2.ProjectRouterGroup)
-		projectV1.GET("", s.DeprecatedBy(dmsV2.GroupV2))
+		projectV1.GET("", s.DMSController.ListProjectsV2) // 兼容jet brain插件，临时开放v1接口
 		projectV1.POST("", s.DeprecatedBy(dmsV2.GroupV2))
 		projectV1.DELETE("/:project_uid", s.DMSController.DelProject)
 		projectV1.PUT("/:project_uid", s.DeprecatedBy(dmsV2.GroupV2))


### PR DESCRIPTION
### **User description**
## issue
https://github.com/actiontech/sqle/issues/3008
## Changes
- Restore ListDBServicesV2 endpoint at v1 level for DMS controller
- Restore ListProjectsV2 endpoint at v1 level for DMS controller
- These changes are to support compatibility with JetBrains plugins

## Why?
有一些用户使用的jetbrain插件会使用到获取数据源和项目的v1的接口，若客户需要升级插件版本，升级成本比较高
且jeb brain中的接口调用除了接口path的版本号不同，其他兼容，因此仅在v1接口上增加调用这两个接口的方法，成本较低
因此临时使用v2的接口方法开放到v1上，来兼容仅支持v1版本调用的插件


___

### **Description**
- 恢复dbService和project接口支持JetBrains插件

- 用ListDBServicesV2和ListProjectsV2替换DeprecatedBy调用

- 保持v2逻辑兼容性


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>router.go</strong><dd><code>更新v1接口调用以支持JetBrains插件</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/apiserver/service/router.go

<li>修改dbServiceV1 GET接口，调用ListDBServicesV2代替DeprecatedBy<br> <li> 修改projectV1 GET接口，调用ListProjectsV2代替DeprecatedBy<br> <li> 添加注释说明兼容JetBrains插件


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/443/files#diff-716d2fbe2c02d196d0887c546f1e9b3b0d15ab44c006685b8242c74f1c60078c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>