### PR TITLE
fix: replace error when len(opPermissionUids) = 0

### DIFF
--- a/internal/dms/storage/member.go
+++ b/internal/dms/storage/member.go
@@ -169,6 +169,7 @@ func (d *MemberRepo) DelRoleFromAllMembers(ctx context.Context, roleUid string) 
 
 func (d *MemberRepo) ReplaceOpPermissionsInMember(ctx context.Context, memberUid string, opPermissionUids []string) error {
 	if len(opPermissionUids) == 0 {
+		// delete all op permissions when op permission uids is empty
 		return transaction(d.log, ctx, d.db, func(tx *gorm.DB) error {
 			member := &model.Member{Model: model.Model{UID: memberUid}}
 			if err := tx.WithContext(ctx).Where("uid = ?", memberUid).First(member).Error; err != nil {


### PR DESCRIPTION
### **User description**
issue: https://github.com/actiontech/sqle-ee/issues/2374


___

### **Description**
- 修复 opPermissionUids 为空时未清除权限问题

- 添加事务操作保证数据一致性

- 增加成员存在性校验及错误处理

- 返回详细错误信息提示异常原因


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>member.go</strong><dd><code>修复空 opPermissionUids 错误模式</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/storage/member.go

- opPermissionUids 为空时执行删除操作
- 使用事务包裹操作确保数据一致性
- 新增成员存在校验及错误处理


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/471/files#diff-e8a830bd3858f25168b93245859e6fb0b48f2389b470b8848e45f1c6fe17ed3c">+16/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>