### PR TITLE
use the latest tag as version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
-# 当前 HEAD 的 tag
-HEAD_TAG = $(shell git describe --exact-match --tags 2>/dev/null)
-
-# 当前分支名
-HEAD_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
-
 # 当前 commit hash
 HEAD_HASH = $(shell git rev-parse HEAD)
+# 尝试获取稳定版标签 (不包含 -pre, -rc, -alpha, -beta 等后缀)
+# grep -Ev '(-alpha|-beta|-rc|-pre)[0-9]*$$' 过滤掉带有预发布后缀的标签
+STABLE_TAG = $(shell git tag --points-at $(HEAD_HASH) --sort=-v:refname | grep -Evi '(-pre)[0-9]*$$' | head -n 1 2>/dev/null)
+
+# 如果没有稳定版标签，则获取最新的预发布标签
+# 注意：这里我们重新获取所有标签，不再过滤，以确保能取到预发布版中最高的
+PRE_RELEASE_TAG = $(shell git tag --points-at $(HEAD_HASH) --sort=-v:refname | head -n 1 2>/dev/null)
+
+# 如果存在稳定版标签，则使用稳定版；否则使用预发布版
+HEAD_TAG := $(if $(STABLE_TAG),$(STABLE_TAG),$(PRE_RELEASE_TAG))
 
 # 1. 如果HEAD存在tag，则GIT_VERSION=<版本名称>-<企业版/社区版> <commit>
 # PS: 通常会在版本名称前增加字符“v”作为tag内容，当版本名称为 3.2411.0时，tag内容为v3.2411.0 
@@ -63,7 +67,9 @@ ifeq ($(IS_PRODUCTION_RELEASE),true)
 # 2. if there is no tag on current commit, means that
 #    current branch is on process.
 #    Set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
-    PROJECT_VERSION = $(shell if [ "$$(git tag --points-at HEAD | tail -n1)" ]; then git tag --points-at HEAD | tail -n1 | sed 's/v\(.*\)/\1/'; else git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1; fi)
+	PROJECT_VERSION = $(if $(HEAD_TAG),\
+    $(shell echo $(HEAD_TAG) | sed 's/v\(.*\)/\1/'),\
+    $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1))
 else
 #    When performing daily packaging, set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
     PROJECT_VERSION = $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1)


### PR DESCRIPTION
### **User description**
https://github.com/actiontech/sqle-ee/issues/2354
link https://github.com/actiontech/sqle/pull/3032


___

### **Description**
- 新增基于 HEAD_HASH 的稳定版与预发布标签获取逻辑

- 优先使用稳定版标签更新 HEAD_TAG 变量

- 更新 PROJECT_VERSION 赋值逻辑，输出无前缀版本号


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>更新标签判断及 PROJECT_VERSION 逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>添加获取稳定版标签(STABLE_TAG)和预发布标签(PRE_RELEASE_TAG)逻辑<br> <li> 使用 if 函数更新 HEAD_TAG，优先使用稳定版标签<br> <li> 修改 PROJECT_VERSION 的生成方式，通过 HEAD_TAG 判断版本号


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/472/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>