### PR TITLE
fix: project admin user can op db

### DIFF
--- a/internal/dms/biz/op_permission_verify.go
+++ b/internal/dms/biz/op_permission_verify.go
@@ -363,8 +363,8 @@ func (o *OpPermissionVerifyUsecase) GetUserProject(ctx context.Context, userUid 
 
 func (o *OpPermissionVerifyUsecase) UserCanOpDB(userOpPermissions []OpPermissionWithOpRange, needOpPermissionTypes []string, dbServiceUid string) bool {
 	for _, userOpPermission := range userOpPermissions {
-		// 对象权限(当前空间内所有对象)
-		if userOpPermission.OpRangeType == OpRangeType(dmsV1.OpRangeTypeProject) {
+		// 项目管理员可以查看所有数据源
+		if userOpPermission.OpPermissionUID == pkgConst.UIDOfOpPermissionProjectAdmin {
 			return true
 		}
 


### PR DESCRIPTION
### **User description**
link: https://github.com/actiontech/sqle/pull/3074
issue: https://github.com/actiontech/sqle-ee/issues/2387#issuecomment-3021913873
- 有项目管理员权限可以通过tips接口查看所有的数据源而不是作用范围是project的权限


___

### **Description**
- 修改项目管理员权限判断逻辑

- 替换条件为检查`pkgConst.UIDOfOpPermissionProjectAdmin`

- 修正权限验证错误


___

### **Changes diagram**

```mermaid
flowchart LR
    A["开始权限校验"] --> B["判断是否为项目管理员"]
    B -- "若为项目管理员" --> C["返回true"]
    B -- "否则" --> D["执行其他权限验证"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>op_permission_verify.go</strong><dd><code>更新项目管理员权限判断逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/biz/op_permission_verify.go

- 修改权限判断条件
- 更新注释解释项目管理员权限变更


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/481/files#diff-52c349b0c96de0cb70b44d85a001a64fb5e6028a2fd37bb8e8e82faa0ae934f1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>