### PR TITLE
build: remove leading and trailing spaces from PROJECT_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,12 +71,12 @@ ifeq ($(IS_PRODUCTION_RELEASE),true)
 # 2. if there is no tag on current commit, means that
 #    current branch is on process.
 #    Set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
-	PROJECT_VERSION = $(if $(HEAD_TAG),\
+	PROJECT_VERSION = $(strip $(if $(HEAD_TAG),\
     $(shell echo $(HEAD_TAG) | sed 's/v\(.*\)/\1/'),\
-    $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1))
+    $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1)))
 else
 #    When performing daily packaging, set rpm name with current branch name(release-1.2109.x-ee or release-1.2109.x -> 1.2109.x).
-    PROJECT_VERSION = $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1)
+    PROJECT_VERSION = $(strip $(shell git rev-parse --abbrev-ref HEAD | sed 's/release-\(.*\)/\1/' | tr '-' '\n' | head -n1))
 endif
 
 override RPM_NAME = $(PROJECT_NAME)-$(EDITION)-$(PROJECT_VERSION).$(RELEASE).$(OS_VERSION).$(RPMBUILD_TARGET).rpm


### PR DESCRIPTION
### **User description**
## 关联的 issue
https://github.com/actiontech/sqle-ee/issues/2354#issuecomment-3149818211

## 描述你的变更
修复makefile构建流程 RPM_NAME 变量包含空格

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`

assign in @LordofAvernus


___

### **Description**
- 移除 PROJECT_VERSION 变量两侧空格

- 使用 strip 函数处理版本号

- 修正 RPM_NAME 拼接逻辑


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Makefile文件"]
  B["添加strip函数处理空格"]
  A -- "处理PROJECT_VERSION变量" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>去除PROJECT_VERSION两侧空格</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- 在HEAD_TAG分支添加strip函数
- 在日常打包分支添加strip函数


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/504/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

