### PR TITLE
feat: add duplicate workflow name validation and localization support

### DIFF
--- a/internal/apiserver/service/dms_controller.go
+++ b/internal/apiserver/service/dms_controller.go
@@ -19,9 +19,11 @@ import (
 	aV1 "github.com/actiontech/dms/api/dms/service/v1"
 	"github.com/actiontech/dms/internal/apiserver/conf"
 	apiError "github.com/actiontech/dms/internal/apiserver/pkg/error"
+	"github.com/actiontech/dms/internal/dms/biz"
 	"github.com/actiontech/dms/internal/dms/pkg/constant"
 	pkgConst "github.com/actiontech/dms/internal/dms/pkg/constant"
 	"github.com/actiontech/dms/internal/dms/service"
+	"github.com/actiontech/dms/internal/pkg/locale"
 	"github.com/labstack/echo/v4/middleware"
 	echoSwagger "github.com/swaggo/echo-swagger"
 
@@ -3692,6 +3694,9 @@ func (ctl *DMSController) AddDataExportWorkflow(c echo.Context) error {
 
 	reply, err := ctl.DMS.AddDataExportWorkflow(c.Request().Context(), req, currentUserUid)
 	if nil != err {
+		if errors.Is(err, biz.ErrDataExportWorkflowNameDuplicate) {
+			return NewErrResp(c, errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.DataExportWorkflowNameDuplicateErr)), apiError.BadRequestErr)
+		}
 		return NewErrResp(c, err, apiError.DMSServiceErr)
 	}
 	return NewOkRespWithReply(c, reply)

--- a/internal/dms/biz/data_export_workflow.go
+++ b/internal/dms/biz/data_export_workflow.go
@@ -2,12 +2,15 @@ package biz
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	pkgConst "github.com/actiontech/dms/internal/dms/pkg/constant"
 	dmsCommonV1 "github.com/actiontech/dms/pkg/dms-common/api/dms/v1"
 	utilLog "github.com/actiontech/dms/pkg/dms-common/pkg/log"
 )
+
+var ErrDataExportWorkflowNameDuplicate = errors.New("data export workflow name duplicate")
 
 type DataExportWorkflowStatus string
 
@@ -98,6 +101,7 @@ type WorkflowStep struct {
 
 type WorkflowRepo interface {
 	SaveWorkflow(ctx context.Context, dataExportWorkflow *Workflow) error
+	IsDataExportWorkflowNameDuplicate(ctx context.Context, projectUID, workflowName string) (bool, error)
 	ListDataExportWorkflows(ctx context.Context, opt *ListWorkflowsOption) ([]*Workflow, int64, error)
 	GetDataExportWorkflow(ctx context.Context, dataExportWorkflowUid string) (*Workflow, error)
 	UpdateWorkflowStatusById(ctx context.Context, dataExportWorkflowUid string, status DataExportWorkflowStatus) error

--- a/internal/dms/service/data_export_workflow.go
+++ b/internal/dms/service/data_export_workflow.go
@@ -25,7 +25,7 @@ func (d *DMSService) AddDataExportWorkflow(ctx context.Context, req *dmsV1.AddDa
 	}
 	uid, err := d.DataExportWorkflowUsecase.AddDataExportWorkflow(ctx, currentUserUid, args)
 	if err != nil {
-		return nil, fmt.Errorf("add data export workflow failed: %v", err)
+		return nil, fmt.Errorf("add data export workflow failed: %w", err)
 	}
 
 	return &dmsV1.AddDataExportWorkflowReply{

--- a/internal/dms/storage/workflow.go
+++ b/internal/dms/storage/workflow.go
@@ -44,6 +44,21 @@ func (d *WorkflowRepo) SaveWorkflow(ctx context.Context, dataExportWorkflow *biz
 	return nil
 }
 
+func (d *WorkflowRepo) IsDataExportWorkflowNameDuplicate(ctx context.Context, projectUID, workflowName string) (bool, error) {
+	var count int64
+	if err := transaction(d.log, ctx, d.db, func(tx *gorm.DB) error {
+		if err := tx.WithContext(ctx).Model(&model.Workflow{}).
+			Where("project_uid = ? AND name = ?", projectUID, workflowName).
+			Count(&count).Error; err != nil {
+			return fmt.Errorf("failed to check workflow name duplicate: %v", err)
+		}
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 func (w *WorkflowRepo) UpdateWorkflowRecord(ctx context.Context, dataExportWorkflowRecord *biz.WorkflowRecord) error {
 	model := convertBizWorkflowRecord(dataExportWorkflowRecord)
 

--- a/internal/pkg/locale/active.en.toml
+++ b/internal/pkg/locale/active.en.toml
@@ -36,6 +36,7 @@ DBServiceSQLQueryRuleTemplateName = "SQL Workbench audit rule template (need to 
 DBServiceSyncExpand = "DB instance synchronization expansion service"
 DBServiceSyncVersion = "Version (Supports DMP5.23.04.0 and above)"
 DBServiceUser = "DB instance connection user"
+DataExportWorkflowNameDuplicateErr = "Duplicate workflow name, please modify the workflow name and resubmit."
 DataWorkflowDefault = "❓ Data Export Workflow Unknown Requests"
 DataWorkflowExportFailed = "⚠️ Data Export Workflow Execute Failed"
 DataWorkflowExportSuccess = "✅ Data Export Workflow Execute Succeeded"

--- a/internal/pkg/locale/active.zh.toml
+++ b/internal/pkg/locale/active.zh.toml
@@ -36,6 +36,7 @@ DBServiceSQLQueryRuleTemplateName = "工作台操作审核规则模板(需要先
 DBServiceSyncExpand = "数据源同步扩展服务"
 DBServiceSyncVersion = "版本(支持DMP5.23.04.0及以上版本)"
 DBServiceUser = "数据源连接用户"
+DataExportWorkflowNameDuplicateErr = "工单名称重复了，请您修改工单名称后重新提交工单。"
 DataWorkflowDefault = "❓数据导出工单未知请求"
 DataWorkflowExportFailed = "⚠️ 数据导出失败"
 DataWorkflowExportSuccess = "✅ 数据导出成功"

--- a/internal/pkg/locale/message_zh.go
+++ b/internal/pkg/locale/message_zh.go
@@ -210,6 +210,7 @@ var (
 
 // Data Export Workflow
 var (
+	DataExportWorkflowNameDuplicateErr      = &i18n.Message{ID: "DataExportWorkflowNameDuplicateErr", Other: "工单名称重复了，请您修改工单名称后重新提交工单。"}
 	DataWorkflowDefault                     = &i18n.Message{ID: "DataWorkflowDefault", Other: "❓数据导出工单未知请求"}
 	DataWorkflowExportFailed                = &i18n.Message{ID: "DataWorkflowExportFailed", Other: "⚠️ 数据导出失败"}
 	DataWorkflowExportSuccess               = &i18n.Message{ID: "DataWorkflowExportSuccess", Other: "✅ 数据导出成功"}


### PR DESCRIPTION
- Introduced a new error for duplicate data export workflow names in the business logic.
- Enhanced the DMSController to return a localized error message when a duplicate name is detected.
- Implemented a method in the WorkflowRepo to check for existing workflow names.
- Updated localization files to include messages for duplicate workflow name errors in both English and Chinese.

## 关联的 issue
https://github.com/actiontech/dms-ee/issues/746

link https://github.com/actiontech/dms-ee/pull/747
## 描述你的变更

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
