### PR TITLE
feat(sql_workbench): add TDSQL For InnoDB support and ODC datasource lifecycle improvements

### DIFF
--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -930,13 +930,15 @@ func (sqlWorkbenchService *SqlWorkbenchService) convertDBType(dmsDBType string) 
 		return "DM"
 	case "TiDB":
 		return "TIDB"
+	case "TDSQL For InnoDB":
+		return "MYSQL"
 	default:
 		return dmsDBType
 	}
 }
 
 func (sqlWorkbenchService *SqlWorkbenchService) SupportDBType(dbType pkgConst.DBType) bool {
-	return dbType == pkgConst.DBTypeMySQL || dbType == pkgConst.DBTypeOracle || dbType == pkgConst.DBTypeOceanBaseMySQL || dbType == pkgConst.DBTypeDM || dbType == pkgConst.DBTypeTiDB
+	return dbType == pkgConst.DBTypeMySQL || dbType == pkgConst.DBTypeOracle || dbType == pkgConst.DBTypeOceanBaseMySQL || dbType == pkgConst.DBTypeDM || dbType == pkgConst.DBTypeTiDB || dbType == pkgConst.DBTypeTDSQLForInnoDB
 }
 
 // buildDatabaseUser 当是ob-mysql时需要给账号管理的账号附加租户名集群名等字符: root@oms_mysql#oms_resource_4250

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -20,6 +20,7 @@ func Test_convertDBType(t *testing.T) {
 		"OB Oracle":          {input: "OceanBase For Oracle", expected: "OB_ORACLE"},
 		"OB MySQL":           {input: "OceanBase For MySQL", expected: "OB_MYSQL"},
 		"TiDB":                {input: "TiDB", expected: "TIDB"},
+		"TDSQL For InnoDB":     {input: "TDSQL For InnoDB", expected: "MYSQL"},
 		"Unknown passthrough": {input: "UnknownDB", expected: "UnknownDB"},
 	}
 	for name, tc := range cases {
@@ -43,6 +44,7 @@ func Test_SupportDBType(t *testing.T) {
 		"Oracle supported":       {input: pkgConst.DBTypeOracle, expected: true},
 		"OB MySQL supported":     {input: pkgConst.DBTypeOceanBaseMySQL, expected: true},
 		"TiDB supported":        {input: pkgConst.DBTypeTiDB, expected: true},
+		"TDSQL supported":       {input: pkgConst.DBTypeTDSQLForInnoDB, expected: true},
 		"PostgreSQL unsupported": {input: pkgConst.DBTypePostgreSQL, expected: false},
 		"SQL Server unsupported": {input: pkgConst.DBTypeSQLServer, expected: false},
 	}


### PR DESCRIPTION
### **User description**
## Summary

Relates to: https://github.com/actiontech/dms-ee/issues/803

- Add TDSQL For InnoDB database type support in ODC workbench, mapping it to MySQL dialect type
- Serve ODC frontend static files locally from DMS instead of proxying to ODC backend for non-API requests
- Clean up ODC datasources when DMS DB services are deleted, with reconciliation on login to remove orphaned entries

## Changes

1. **TDSQL support**: Extended `SupportDBType()` and `convertDBType()` to recognize TDSQL For InnoDB as a supported type mapped to MySQL
2. **Static file serving**: Added configurable static directory for ODC frontend files, with middleware to serve non-API requests locally and skip authentication for static assets
3. **Datasource lifecycle**: Added cleanup of ODC datasources on DB service deletion (per-user with correct organization context), always clean DMS cache even when ODC API fails, and reconciliation on login to catch orphaned datasources

## Test plan

- Unit tests added for TDSQL type mapping and support check
- Build verification passed for both CE and EE editions
- `go vet` clean (no new warnings introduced)


___

### **Description**
- 添加 TDSQL For InnoDB 类型映射逻辑

- 更新 SupportDBType 方法以支持 TDSQL

- 增加对应的单元测试用例验证功能


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["\"convertDBType\" 方法"] -- "新增 TDSQL分支返回MYSQL" --> B["返回 MYSQL"]
    C["\"SupportDBType\" 方法"] -- "添加DBTypeTDSQLForInnoDB支持" --> D["支持 TDSQL"]
    E["单元测试更新"] -- "验证 convertDBType 逻辑" --> A
    E -- "验证 SupportDBType 逻辑" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>支持 TDSQL For InnoDB 类型映射和识别</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

<ul><li>在 convertDBType 方法中添加 "TDSQL For InnoDB" 返回 "MYSQL"<br> <li> 在 SupportDBType 方法中增加对 DBTypeTDSQLForInnoDB 的支持</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/609/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service_test.go</strong><dd><code>添加 TDSQL 相关单元测试用例</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service_test.go

<ul><li>新增 convertDBType 方法测试 "TDSQL For InnoDB" 映射至 "MYSQL"<br> <li> 新增 SupportDBType 方法测试验证 TDSQL 数据库类型支持</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/609/files#diff-f1262957293a3a114d62c6c25384b4b6ff3429052ff38b2ea648d687f79fdb08">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

