### PR TITLE
fix: skip ODC query path in static file middleware (#815)

### DIFF
--- a/internal/apiserver/service/router.go
+++ b/internal/apiserver/service/router.go
@@ -436,6 +436,9 @@ func (s *APIServer) installMiddleware() error {
 			if strings.HasPrefix(c.Request().URL.Path, s.SqlWorkbenchController.CloudbeaverService.CloudbeaverUsecase.GetRootUri()) {
 				return true
 			}
+			if strings.HasPrefix(c.Request().URL.Path, s.SqlWorkbenchController.SqlWorkbenchService.GetRootUri()) {
+				return true
+			}
 			if strings.HasPrefix(c.Request().URL.Path, "/provision/v") ||
 				strings.HasPrefix(c.Request().URL.Path, "/sqle/v") {
 				return true


### PR DESCRIPTION
### **User description**
Skip ODC query path in static file middleware to prevent fallback interception, ensuring Provision TDSQL data source sync works correctly through the DMS proxy layer.

Related Issue: https://github.com/actiontech/dms-ee/issues/815


___

### **Description**
- 新增对 `SqlWorkbenchService.GetRootUri()` 判断

- 修正静态文件中间件拦截 ODC 查询路径问题

- 确保代理层正确转发请求


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["检测 Cloudbeaver 请求"] -- "已有判断" --> B["跳过静态中间件"]
  A2["检测 SqlWorkbench 请求"] -- "新增加判断" --> B
  C["检测 provision/sqle 路径"] -- "已有判断" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>router.go</strong><dd><code>在静态中间件中添加 ODC 查询跳过逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/apiserver/service/router.go

- 添加判断逻辑，跳过 `SqlWorkbenchService.GetRootUri()`
- 修正静态中间件对 ODC 查询路径的拦截


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/616/files#diff-716d2fbe2c02d196d0887c546f1e9b3b0d15ab44c006685b8242c74f1c60078c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

