### PR TITLE
feat(data_export): register PolarDB For MySQL and OceanBase For Oracle as supported DB types

### DIFF
--- a/internal/dms/pkg/constant/const.go
+++ b/internal/dms/pkg/constant/const.go
@@ -253,7 +253,9 @@ func ParseDBType(s string) (DBType, error) {
 	case "HANA":
 		return DBTypeHANA, nil
 	case "PolarDB For MySQL":
-		return DBTypePolarDBMySQL, nil
+		return DBTypePolarDBForMySQL, nil
+	case "OceanBase For Oracle":
+		return DBTypeOceanBaseOracle, nil
 
 	default:
 		return "", fmt.Errorf("invalid db type: %s", s)
@@ -274,8 +276,9 @@ const (
 	DBTypeHive           DBType = "Hive"
 	DBTypeDM             DBType = "达梦(DM)"
 	DBTypeGaussDB        DBType = "GaussDB / openGauss"
-	DBTypeHANA           DBType = "HANA"
-	DBTypePolarDBMySQL   DBType = "PolarDB For MySQL"
+	DBTypeHANA              DBType = "HANA"
+	DBTypePolarDBForMySQL   DBType = "PolarDB For MySQL"
+	DBTypeOceanBaseOracle   DBType = "OceanBase For Oracle"
 )
 
 var supportedDataExportDBTypes = map[DBType]struct{}{
@@ -293,8 +296,9 @@ var supportedDataExportDBTypes = map[DBType]struct{}{
 	DBTypeTBase:          {},
 	DBTypeGaussDB:        {},
 	DBTypeDB2:            {},
-	DBTypeHANA:           {},
-	DBTypePolarDBMySQL:   {},
+	DBTypeHANA:              {},
+	DBTypePolarDBForMySQL:   {},
+	DBTypeOceanBaseOracle:   {},
 }
 
 func CheckDBTypeIfDataExportSupported(dbtype string) bool {


### PR DESCRIPTION
### **User description**
## Summary

- Register `DBTypePolarDBForMySQL` and `DBTypeOceanBaseOracle` as new DB type constants
- Add both types to `ParseDBType` function and `supportedDataExportDBTypes` map
- Enables data export support for PolarDB For MySQL and OceanBase For Oracle instances

Fixes https://github.com/actiontech/sqle-ee/issues/2815


___

### **Description**
- 注册PolarDB For MySQL常量

- 新增OceanBase For Oracle常量

- 更新ParseDBType函数新增分支条件

- 更新supportedDataExportDBTypes映射，支持新类型


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["更新ParseDBType函数"] -- "添加PolarDB For MySQL分支" --> B["返回DBTypePolarDBForMySQL"]
  A -- "添加OceanBase For Oracle分支" --> C["返回DBTypeOceanBaseOracle"]
  D["更新DB类型常量"] -- "新增OceanBase For Oracle常量" --> E["支持数据导出"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>const.go</strong><dd><code>修改函数和常量支持新数据库类型</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/pkg/constant/const.go

<ul><li>修改ParseDBType函数，调整数据库类型判断逻辑<br> <li> 替换DBTypePolarDBMySQL为DBTypePolarDBForMySQL<br> <li> 新增对OceanBase For Oracle的支持分支<br> <li> 更新supportedDataExportDBTypes映射以包含新类型</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/617/files#diff-f73102f4630133e7d63ff7bd39086da745907c9ced4ee43b64c48b5260dabcd9">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

