### PR TITLE
Ce polardb pr 816

### DIFF
--- a/internal/dms/pkg/constant/const.go
+++ b/internal/dms/pkg/constant/const.go
@@ -252,6 +252,8 @@ func ParseDBType(s string) (DBType, error) {
 		return DBTypeGaussDB, nil
 	case "HANA":
 		return DBTypeHANA, nil
+	case "PolarDB For MySQL":
+		return DBTypePolarDBMySQL, nil
 
 	default:
 		return "", fmt.Errorf("invalid db type: %s", s)
@@ -273,6 +275,7 @@ const (
 	DBTypeDM             DBType = "达梦(DM)"
 	DBTypeGaussDB        DBType = "GaussDB / openGauss"
 	DBTypeHANA           DBType = "HANA"
+	DBTypePolarDBMySQL   DBType = "PolarDB For MySQL"
 )
 
 var supportedDataExportDBTypes = map[DBType]struct{}{
@@ -291,6 +294,7 @@ var supportedDataExportDBTypes = map[DBType]struct{}{
 	DBTypeGaussDB:        {},
 	DBTypeDB2:            {},
 	DBTypeHANA:           {},
+	DBTypePolarDBMySQL:   {},
 }
 
 func CheckDBTypeIfDataExportSupported(dbtype string) bool {

--- a/internal/dms/pkg/constant/const_test.go
+++ b/internal/dms/pkg/constant/const_test.go
@@ -14,6 +14,7 @@ func TestCheckDBTypeIfDataExportSupported_NewTypes(t *testing.T) {
 		"GaussDB for MySQL": true, // GaussDB/openGauss: ParseDBType 的输入值是 "GaussDB for MySQL"
 		"DB2":               true,
 		"HANA":              true,
+		"PolarDB For MySQL": true,
 	}
 	for dbType, expectedSupported := range newTypes {
 		t.Run(dbType, func(t *testing.T) {
@@ -41,6 +42,42 @@ func TestCheckDBTypeIfDataExportSupported_ExistingTypes(t *testing.T) {
 			got := CheckDBTypeIfDataExportSupported(dbType)
 			if got != expectedSupported {
 				t.Errorf("CheckDBTypeIfDataExportSupported(%q) = %v, want %v", dbType, got, expectedSupported)
+			}
+		})
+	}
+}
+
+func TestParseDBType_PolarDB(t *testing.T) {
+	cases := map[string]struct {
+		input       string
+		wantDBType  DBType
+		wantErr     bool
+	}{
+		"valid PolarDB For MySQL": {
+			input:      "PolarDB For MySQL",
+			wantDBType: DBTypePolarDBMySQL,
+			wantErr:    false,
+		},
+		"invalid lowercase polardb": {
+			input:      "polardb for mysql",
+			wantDBType: "",
+			wantErr:    true,
+		},
+		"invalid partial match": {
+			input:      "PolarDB",
+			wantDBType: "",
+			wantErr:    true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseDBType(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ParseDBType(%q) error = %v, wantErr %v", tc.input, err, tc.wantErr)
+				return
+			}
+			if got != tc.wantDBType {
+				t.Errorf("ParseDBType(%q) = %v, want %v", tc.input, got, tc.wantDBType)
 			}
 		})
 	}

--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -937,6 +937,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) convertDBType(dmsDBType string) 
 		return "MYSQL"
 	case "GoldenDB":
 		return "MYSQL"
+	case "PolarDB For MySQL":
+		return "MYSQL"
 	default:
 		return dmsDBType
 	}

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -22,6 +22,7 @@ func Test_convertDBType(t *testing.T) {
 		"TiDB":                {input: "TiDB", expected: "TIDB"},
 		"TDSQL For InnoDB":     {input: "TDSQL For InnoDB", expected: "MYSQL"},
 		"GoldenDB":            {input: "GoldenDB", expected: "MYSQL"},
+		"PolarDB For MySQL":   {input: "PolarDB For MySQL", expected: "MYSQL"},
 		"Unknown passthrough": {input: "UnknownDB", expected: "UnknownDB"},
 	}
 	for name, tc := range cases {
@@ -49,6 +50,7 @@ func Test_SupportDBType(t *testing.T) {
 		"GoldenDB supported":    {input: pkgConst.DBTypeGoldenDB, expected: true},
 		"PostgreSQL unsupported": {input: pkgConst.DBTypePostgreSQL, expected: false},
 		"SQL Server unsupported": {input: pkgConst.DBTypeSQLServer, expected: false},
+		"PolarDB MySQL unsupported":  {input: pkgConst.DBTypePolarDBMySQL, expected: false},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### **User description**
https://github.com/actiontech/dms-ee/issues/816

link https://github.com/actiontech/dms-ee/pull/833


___

### **Description**
- 新增对 `PolarDB For MySQL` 的 DB 类型支持

- 修改常量定义、解析及数据导出白名单

- 更新工作台服务中 DB 类型转换逻辑

- 添加对应单元测试覆盖新功能


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ParseDBType逻辑"] -- "匹配新增类型" --> B["PolarDB For MySQL常量"]
  B -- "添加到白名单" --> C["supportedDataExportDBTypes"]
  D["sql_workbench_service转换逻辑"] -- "映射新类型" --> E["返回 MYSQL"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>const.go</strong><dd><code>添加 PolarDB For MySQL 支持逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/pkg/constant/const.go

<ul><li>新增 <code>PolarDB For MySQL</code> 解析分支<br> <li> 定义 <code>DBTypePolarDBMySQL</code> 常量<br> <li> 更新数据导出白名单支持</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/619/files#diff-f73102f4630133e7d63ff7bd39086da745907c9ced4ee43b64c48b5260dabcd9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>更新 DB 类型转换映射</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

- 添加 `PolarDB For MySQL` 映射返回 "MYSQL"


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/619/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>const_test.go</strong><dd><code>测试新增 DB 类型支持</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/pkg/constant/const_test.go

- 更新白名单测试，包含新类型
- 添加 `TestParseDBType_PolarDB` 测试函数


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/619/files#diff-e67cb9f0b424e5b03022b451cc7b8a4fa7828c8446596ece9df84b7355385029">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service_test.go</strong><dd><code>新增 DMS 转换单元测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service_test.go

- 新增测试验证 `PolarDB For MySQL` 转换
- 检查支持逻辑返回预期结果


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/619/files#diff-f1262957293a3a114d62c6c25384b4b6ff3429052ff38b2ea648d687f79fdb08">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

