### PR TITLE
feat(dms): support PolarDB For MySQL DBType in DMS (#826)

### DIFF
--- a/internal/dms/biz/cloudbeaver.go
+++ b/internal/dms/biz/cloudbeaver.go
@@ -1765,7 +1765,7 @@ func (cu *CloudbeaverUsecase) GenerateCloudbeaverConnectionParams(dbService *DBS
 		return nil, err
 	}
 	switch dbType {
-	case constant.DBTypeMySQL, constant.DBTypeTDSQLForInnoDB:
+	case constant.DBTypeMySQL, constant.DBTypeTDSQLForInnoDB, constant.DBTypePolarDBForMySQL:
 		err = cu.fillMySQLParams(config)
 	case constant.DBTypeTiDB:
 		err = cu.fillTiDBParams(config)

--- a/internal/dms/biz/cloudbeaver_test.go
+++ b/internal/dms/biz/cloudbeaver_test.go
@@ -1,0 +1,77 @@
+package biz
+
+import (
+	"testing"
+
+	utilLog "github.com/actiontech/dms/pkg/dms-common/pkg/log"
+)
+
+// Test_GenerateCloudbeaverConnectionParams_PolarDB covers design.md §11.2 Table 4
+// (plan 5.10): verifies PolarDB DbService reuses fillMySQLParams to write the
+// MySQL driverId and allowPublicKeyRetrieval properties, and that MySQL keeps
+// the same behavior as a regression guard.
+func Test_GenerateCloudbeaverConnectionParams_PolarDB(t *testing.T) {
+	cu := &CloudbeaverUsecase{
+		log: utilLog.NewHelper(&noopLogger{}, utilLog.WithMessageKey("test")),
+	}
+
+	cases := map[string]struct {
+		dbType                   string
+		wantDriverID             string
+		wantAllowPublicKeyRetVal string
+	}{
+		// (a) PolarDB happy: driverId == "mysql:mysql8" (plan 3.3)
+		"PolarDB driverId is mysql:mysql8": {
+			dbType:                   "PolarDB For MySQL",
+			wantDriverID:             "mysql:mysql8",
+			wantAllowPublicKeyRetVal: "TRUE",
+		},
+		// (b) PolarDB happy: properties.allowPublicKeyRetrieval == "TRUE" (fillMySQLParams reuse)
+		"PolarDB allowPublicKeyRetrieval is TRUE": {
+			dbType:                   "PolarDB For MySQL",
+			wantDriverID:             "mysql:mysql8",
+			wantAllowPublicKeyRetVal: "TRUE",
+		},
+		// (c) MySQL regression: confirm existing MySQL behavior is unchanged
+		"MySQL regression keeps driverId mysql:mysql8": {
+			dbType:                   "MySQL",
+			wantDriverID:             "mysql:mysql8",
+			wantAllowPublicKeyRetVal: "TRUE",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dbService := &DBService{
+				Name:     "test-instance",
+				DBType:   tc.dbType,
+				Host:     "127.0.0.1",
+				Port:     "3306",
+				User:     "root",
+				Password: "pwd",
+			}
+
+			resp, err := cu.GenerateCloudbeaverConnectionParams(dbService, "proj", "")
+			if err != nil {
+				t.Fatalf("GenerateCloudbeaverConnectionParams err: %v", err)
+			}
+
+			config, ok := resp["config"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("config is not map[string]interface{}: %T", resp["config"])
+			}
+
+			if got := config["driverId"]; got != tc.wantDriverID {
+				t.Errorf("driverId = %v, want %v", got, tc.wantDriverID)
+			}
+
+			props, ok := config["properties"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("properties is not map[string]interface{}: %T", config["properties"])
+			}
+			if got := props["allowPublicKeyRetrieval"]; got != tc.wantAllowPublicKeyRetVal {
+				t.Errorf("allowPublicKeyRetrieval = %v, want %v", got, tc.wantAllowPublicKeyRetVal)
+			}
+		})
+	}
+}

--- a/internal/dms/pkg/constant/const_test.go
+++ b/internal/dms/pkg/constant/const_test.go
@@ -121,6 +121,10 @@ func TestParseDBType(t *testing.T) {
 		"DM":                 {input: "DM", expected: DBTypeDM},
 		"GaussDB for MySQL":  {input: "GaussDB for MySQL", expected: DBTypeGaussDB},
 		"HANA":               {input: "HANA", expected: DBTypeHANA},
+		// PolarDB-MySQL 新增 (Issue #826)
+		"PolarDB For MySQL":  {input: "PolarDB For MySQL", expected: DBTypePolarDBForMySQL},
+		// "PolarDB" 单独不应匹配
+		"PolarDB only":       {input: "PolarDB", expectError: true},
 		"invalid type":       {input: "UnknownDB", expectError: true},
 		"empty string":       {input: "", expectError: true},
 	}

--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -961,7 +961,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) SupportDBType(dbType pkgConst.DB
 		dbType == pkgConst.DBTypeDM ||
 		dbType == pkgConst.DBTypeTiDB ||
 		dbType == pkgConst.DBTypeTDSQLForInnoDB ||
-		dbType == pkgConst.DBTypeGoldenDB
+		dbType == pkgConst.DBTypeGoldenDB ||
+		dbType == pkgConst.DBTypePolarDBForMySQL
 }
 
 // buildDatabaseUser 当是ob-mysql时需要给账号管理的账号附加租户名集群名等字符: root@oms_mysql#oms_resource_4250

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -50,7 +50,7 @@ func Test_SupportDBType(t *testing.T) {
 		"GoldenDB supported":    {input: pkgConst.DBTypeGoldenDB, expected: true},
 		"PostgreSQL unsupported": {input: pkgConst.DBTypePostgreSQL, expected: false},
 		"SQL Server unsupported": {input: pkgConst.DBTypeSQLServer, expected: false},
-		"PolarDB MySQL unsupported":  {input: pkgConst.DBTypePolarDBMySQL, expected: false},
+		"PolarDB For MySQL supported":  {input: pkgConst.DBTypePolarDBForMySQL, expected: true},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### **User description**
Fixes actiontech/dms-ee#826

## 概要

为 PolarDB-MySQL 数据源接入 Provision 账号权限管控链路的 dms（CE）端改动。

## 变更内容

- `internal/dms/pkg/constant/const.go`：DBType 常量段尾部追加 `DBTypePolarDBForMySQL = "PolarDB For MySQL"`；`ParseDBType` switch 追加分支。
- `internal/dms/biz/cloudbeaver.go`：CloudBeaver 数据源参数构造 / `SupportDBType` 走 MySQL 协议路径。
- `internal/sql_workbench/service/sql_workbench_service.go`：`convertDBType` 末尾追加 `"PolarDB For MySQL" → "MYSQL"`；`SupportDBType` 增加 `dbType == pkgConst.DBTypePolarDBForMySQL` 判断。
- 测试：`internal/dms/pkg/constant/const_test.go` / `internal/dms/biz/cloudbeaver_test.go` / `internal/sql_workbench/service/sql_workbench_service_test.go` 各自追加 PolarDB map case。

## 兼容性

走 A 类完全规避：所有新增分支均在 switch 末尾或 case 列表合并位追加，老 case 字面量、返回值、default 行为未改动；CloudBeaver fillMySQLParams 函数体未改动；ODC convertDBType 字面量未替换为常量比对。详见 docs/dev/compat_risks.md compat-RISK-1 / compat-RISK-3。

## 测试结果

- `go test -vet=off -count=1 ./internal/dms/biz/ ./internal/dms/pkg/constant/ ./internal/sql_workbench/service/` PASS

## 关联 EE PR

EE 专有 `_ee.go` 部分见 actiontech/dms-ee#843。


___

### **Description**
- 增加 PolarDB For MySQL 数据源支持

- Cloudbeaver 参数生成复用 MySQL 逻辑

- 扩充 ParseDBType 与 SQLWorkbench 支持分支

- 添加单元测试验证新功能行为


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CB["\"CloudbeaverUsecase增强\""]
  CT["\"常量解析与测试扩充\""]
  SW["\"SQLWorkbench支持增强\""]
  CB -- "复用 MySQL 逻辑" --> CT
  CT -- "验证新 DBType" --> SW
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudbeaver.go</strong><dd><code>Cloudbeaver 新增 PolarDB 数据源支持</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/biz/cloudbeaver.go

- 添加 `DBTypePolarDBForMySQL` 分支
- 更新 switch 语句复用 fillMySQLParams


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/621/files#diff-87b08a1658e7e3f486c31d72330f59fb08325ea86ca6de55bdf91668d7277e51">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>SQLWorkbench 支持 PolarDB 更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

- 更新支持列表增加 PolarDB For MySQL 分支
- 保持原有逻辑不变


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/621/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudbeaver_test.go</strong><dd><code>新增 Cloudbeaver PolarDB 测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/biz/cloudbeaver_test.go

- 新增针对 PolarDB 的测试用例
- 验证 driverId 与 allowPublicKeyRetrieval 设置


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/621/files#diff-1625acbaf812799572dd82e5de3dce78ece7e30c9aa2d15c2b7812ad9d2e4ac4">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>const_test.go</strong><dd><code>增加 ParseDBType PolarDB 测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/pkg/constant/const_test.go

- 扩充 ParseDBType 测试用例
- 增加对 PolarDB For MySQL 正常及异常情况检测


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/621/files#diff-e67cb9f0b424e5b03022b451cc7b8a4fa7828c8446596ece9df84b7355385029">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service_test.go</strong><dd><code>SQLWorkbench 测试更新验证 PolarDB</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service_test.go

- 调整测试用例验证 PolarDB 支持
- 更新预期值和断言条件


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/621/files#diff-f1262957293a3a114d62c6c25384b4b6ff3429052ff38b2ea648d687f79fdb08">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

