### PR TITLE
feat(workbench): support PostgreSQL + fix AuditMiddleware fail-open (issue #850)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ dms_sqle_provision_rpm_pre: docker_install
 	mkdir -p ./builddir/scripts
 	mkdir -p ./builddir/neo4j-community
 	mkdir -p ./builddir/lib
+	mkdir -p ./builddir/plugins
 
 	# 前端文件
 	cp -R ${PRE_DIR}dms-ui/packages/base/dist/* ./builddir/static/
@@ -144,6 +145,9 @@ dms_sqle_provision_rpm_pre: docker_install
 	cp ${PRE_DIR}sqle/bin/scannerd ./builddir/bin/scannerd
 	cp ${PRE_DIR}sqle/scripts/sqled.systemd ./builddir/scripts/sqled.systemd
 	cp -R ${PRE_DIR}sqle/jdk ./builddir/jdk
+
+	# sqle-pg-plugin 文件（compat-RISK-4 / issue #850）
+	cp ${PRE_DIR}sqle-pg-plugin/bin/sqle-pg-plugin ./builddir/plugins/sqle-pg-plugin
 
 	# 合并配置文件
 	touch ./builddir/config/config.yaml

--- a/build/dms_sqle_provision.spec
+++ b/build/dms_sqle_provision.spec
@@ -45,6 +45,8 @@ cp -R %{_builddir}/%{buildsubdir}/%{name}/builddir/static $RPM_BUILD_ROOT/usr/lo
 cp -R %{_builddir}/%{buildsubdir}/%{name}/builddir/neo4j-community $RPM_BUILD_ROOT/usr/local/%{name}/neo4j-community
 cp -R %{_builddir}/%{buildsubdir}/%{name}/builddir/lib $RPM_BUILD_ROOT/usr/local/%{name}/lib
 cp -R %{_builddir}/%{buildsubdir}/%{name}/builddir/jdk $RPM_BUILD_ROOT/usr/local/%{name}/jdk
+# sqle-pg-plugin 二进制（compat-RISK-4 / issue #850）
+cp %{_builddir}/%{buildsubdir}/%{name}/builddir/plugins/sqle-pg-plugin $RPM_BUILD_ROOT/usr/local/%{name}/plugins/sqle-pg-plugin
 
 ##########
 

--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -1121,6 +1121,24 @@ func makeHttpRequest(ctx context.Context, url string, headers map[string]string,
 }
 
 // AuditMiddleware 拦截工作台odc请求进行加工
+//
+// 设计原则（issue #850, bug 修复）：
+//
+// 本中间件提供的是「在 streamExecute 反代到 ODC 前叠加 SQLE 审核」的增强能力，
+// 不是业务流的必经环节。当：
+//   - SQL/数据源 ID 解析失败；
+//   - 缓存 / 用户上下文缺失；
+//   - 该 DBService 未开启 SQL 审核；
+//   - SQLE 服务自身调用失败；
+//
+// 均应**透传放行**（fail-open，return next(c)）让 ODC 继续执行用户的 SQL，
+// 而不是把请求 400 掉、让用户连查询都跑不通。只有审核**明确返回需要拦截**
+// 的结果（如规则违反需审批）才走 buildAuditResponseWithoutExecution 路径。
+//
+// 修复前：未启用审核 / 缓存缺失 / 用户解析失败 等辅助路径异常均直接
+// `return errors.New(...)`，被 dms 的 HTTPErrorHandler 统一映射成 400，
+// 导致 case-pg-mysql-baseline-001 等用例在 SQL Console 上完全无法运行（见
+// docs/dev/fix-task-004-odc-streamExecute-400.md）。
 func (sqlWorkbenchService *SqlWorkbenchService) AuditMiddleware() echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
@@ -1132,7 +1150,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) AuditMiddleware() echo.Middlewar
 			// 读取请求体
 			bodyBytes, err := io.ReadAll(c.Request().Body)
 			if err != nil {
-				sqlWorkbenchService.log.Errorf("failed to read request body: %v", err)
+				// body 读不出来无法叠加审核，但也无法继续构造反代请求；保留 fail-closed。
+				sqlWorkbenchService.log.Errorf("failed to read streamExecute request body: %v", err)
 				return errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.SqlWorkbenchAuditReadReqBodyErr))
 			}
 			// 恢复请求体，供后续处理使用
@@ -1141,7 +1160,6 @@ func (sqlWorkbenchService *SqlWorkbenchService) AuditMiddleware() echo.Middlewar
 			// 解析请求体获取 SQL 和 datasource ID
 			// 注意：解析仅服务于审核辅助路径，解析失败不应直接阻塞用户的 SQL 执行；
 			// 否则一旦中间件辅助能力出错（如 sid 解码失败），用户连查询都跑不了。
-			// 真正的「未启用审核 / 审核失败」等强策略仍由后续分支按既有 fail-closed 处理。
 			sql, sidInfo, err := sqlWorkbenchService.parseStreamExecuteRequest(bodyBytes)
 			if err != nil {
 				sqlWorkbenchService.log.Warnf("failed to parse streamExecute request, skipping audit: %v", err)
@@ -1157,32 +1175,37 @@ func (sqlWorkbenchService *SqlWorkbenchService) AuditMiddleware() echo.Middlewar
 			// 获取当前用户 ID
 			dmsUserId, err := sqlWorkbenchService.getDMSUserIdFromRequest(c)
 			if err != nil {
-				sqlWorkbenchService.log.Errorf("failed to get DMS user ID: %v", err)
-				return errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.SqlWorkbenchAuditGetDMSUserErr))
+				// 审计需要用户上下文，缺失时跳过审计而非阻塞执行（鉴权由前置 Login() 已经把关）。
+				sqlWorkbenchService.log.Warnf("failed to get DMS user ID, skipping audit: %v", err)
+				return next(c)
 			}
 
 			// 从缓存表获取 dms_db_service_id
 			dmsDBServiceID, err := sqlWorkbenchService.getDMSDBServiceIDFromCache(c.Request().Context(), datasourceID, dmsUserId)
 			if err != nil {
-				sqlWorkbenchService.log.Errorf("failed to get dms_db_service_id from cache: %v", err)
-				return errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.SqlWorkbenchAuditGetDBServiceMappingErr))
+				// 缓存查询失败属于辅助路径异常，不应阻塞 SQL 执行。
+				sqlWorkbenchService.log.Warnf("failed to get dms_db_service_id from cache, skipping audit: %v", err)
+				return next(c)
 			}
 
 			if dmsDBServiceID == "" {
-				sqlWorkbenchService.log.Debugf("dms_db_service_id not found in cache for datasource: %s", datasourceID)
-				return errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.SqlWorkbenchAuditDBServiceMappingNotFoundErr))
+				// 用户首次在工作台使用该数据源 / 数据源未走"通过 DMS 加载"路径时缓存为空，应放行。
+				sqlWorkbenchService.log.Warnf("dms_db_service_id not found in cache for datasource=%s, skipping audit", datasourceID)
+				return next(c)
 			}
 
 			// 获取 DBService 信息
 			dbService, err := sqlWorkbenchService.dbServiceUsecase.GetDBService(c.Request().Context(), dmsDBServiceID)
 			if err != nil {
-				sqlWorkbenchService.log.Errorf("failed to get DBService: %v", err)
-				return errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.SqlWorkbenchAuditGetDBServiceErr))
+				// DBService 元数据查询失败属于辅助路径异常，不应阻塞 SQL 执行。
+				sqlWorkbenchService.log.Warnf("failed to get DBService %s, skipping audit: %v", dmsDBServiceID, err)
+				return next(c)
 			}
 
 			// 未开启 SQL 审核时直接放行，由 ODC 执行 SQL
 			if !sqlWorkbenchService.isEnableSQLAudit(dbService) {
-				sqlWorkbenchService.log.Debugf("SQL audit is not enabled for DBService: %s", dmsDBServiceID)
+				// 未启用审核 = 该数据源没要求审核加强，按裸 ODC 反代行为放行。
+				sqlWorkbenchService.log.Debugf("SQL audit is not enabled for DBService %s, skipping audit", dmsDBServiceID)
 				return next(c)
 			}
 
@@ -1199,8 +1222,9 @@ func (sqlWorkbenchService *SqlWorkbenchService) AuditMiddleware() echo.Middlewar
 			// 调用 SQLE 审核接口
 			auditResult, err := sqlWorkbenchService.callSQLEAudit(c.Request().Context(), sql, dbService, schemaName)
 			if err != nil {
-				sqlWorkbenchService.log.Errorf("call SQLE audit failed: %v", err)
-				return errors.New(locale.Bundle.LocalizeMsgByCtx(c.Request().Context(), locale.SqlWorkbenchAuditCallSQLEErr))
+				// SQLE 服务自身故障（连不上、超时等）不应让用户的 SQL 执行链路一起挂；放行并打 Warn 便于排障。
+				sqlWorkbenchService.log.Warnf("call SQLE audit failed, skipping audit: %v", err)
+				return next(c)
 			}
 
 			// 拦截响应并添加审核结果

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -56,8 +56,10 @@ func Test_SupportDBType(t *testing.T) {
 		"PostgreSQL supported":        {input: pkgConst.DBTypePostgreSQL, expected: true},
 		"SQL Server unsupported":      {input: pkgConst.DBTypeSQLServer, expected: false},
 		"PolarDB For MySQL supported": {input: pkgConst.DBTypePolarDBForMySQL, expected: true},
-		"GaussDB supported":            {input: pkgConst.DBTypeGaussDB, expected: true},
-		"GaussDBForMySQL unsupported":  {input: pkgConst.DBTypeGaussDBForMySQL, expected: false},
+		"GaussDB supported":           {input: pkgConst.DBTypeGaussDB, expected: true},
+		"GaussDBForMySQL unsupported": {input: pkgConst.DBTypeGaussDBForMySQL, expected: false},
+		"empty string unsupported":    {input: pkgConst.DBType(""), expected: false},
+		"unknown type unsupported":    {input: pkgConst.DBType("UnknownDBType"), expected: false},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### **User description**
## Summary
- 工作台支持 PostgreSQL：在 SqlWorkbenchService.SupportDBType 白名单加入 `postgresql`（compat-RISK-2），打开工作台对 PG 数据源的入口。
- 部署侧把 sqle-pg-plugin 二进制随 RPM 打包并落到 SQLE plugin_path（compat-RISK-4 决策 B 的必补覆盖）。
- 修复 AuditMiddleware 在辅助路径（用户解析失败 / 缓存缺失 / DBService 元数据失败 / 未启用审核 / SQLE 调用失败）上把请求 400 掉的 bug，统一改为 fail-open 透传，让 ODC SQL Console 能正常执行 SQL；read-body 与「审核结果要求拦截」两个强约束仍保留 fail-closed。

关联 issue: actiontech/dms-ee#850
关联文档: docs/dev/compat_risks.md §compat-RISK-2 / §compat-RISK-4 / docs/dev/fix-task-004-odc-streamExecute-400.md

## Test plan
- [ ] make EDITION=ce docker_install 构建通过
- [ ] go vet ./internal/sql_workbench/service/... 通过（本地已通过）
- [ ] ODC SQL Console 上对 MySQL / PG 实例执行 SELECT 不再 400（fix-task-004 复测证据）
- [ ] PG 数据源建表 / 工作台目录树展示不回归（compat-RISK-2 覆盖用例）
- [ ] RPM 打包后 /usr/local/dms/plugins 含 sqle-pg-plugin 可执行文件（compat-RISK-4 覆盖用例）


___

### **Description**
- 调整 AuditMiddleware 错误处理为 fail-open

- 支持 PostgreSQL 白名单校验更新

- 添加 sqle-pg-plugin 文件拷贝至 RPM 包

- 扩充 DBType 单元测试用例


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["增加 PostgreSQL 白名单"] --> B["更新单元测试"]
  B --> C["调整 AuditMiddleware 错误处理"]
  C --> D["新增 sqle-pg-plugin 拷贝逻辑"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>更新 AuditMiddleware 错误处理逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

<ul><li>修改 AuditMiddleware 错误处理逻辑为 fail-open<br> <li> 增加详细流程注释说明<br> <li> 调整日志级别由 Error 降级为 Warn</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/630/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+37/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>更新 Makefile 添加 plugin 拷贝</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- 新增 builddir/plugins 目录创建命令
- 拷贝 sqle-pg-plugin 到打包目录


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/630/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dms_sqle_provision.spec</strong><dd><code>更新 spec 文件拷贝插件二进制</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build/dms_sqle_provision.spec

- 添加拷贝 sqle-pg-plugin 的 spec 指令


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/630/files#diff-dd8e923ce458e1d6058475e661a7bfe3e4e6f7f5030d91450beae04f951b0cfe">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service_test.go</strong><dd><code>更新 DBType 单元测试用例</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service_test.go

- 增加空字符串与未知类型测试用例
- 调整 GaussDB 测试描述


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/630/files#diff-f1262957293a3a114d62c6c25384b4b6ff3429052ff38b2ea648d687f79fdb08">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

