### PR TITLE
fix(sql_workbench): normalize SQL Server audit schema to catalog name

### DIFF
--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -1441,6 +1441,19 @@ func (sqlWorkbenchService *SqlWorkbenchService) isEnableSQLAudit(dbService *biz.
 	return dbService.SQLEConfig.AuditEnabled && dbService.SQLEConfig.SQLQueryConfig.AuditEnabled
 }
 
+// normalizeSQLEAuditSchemaName 将 ODC SQL Server 的 database.schema 组合归一化为 SQLE 连接库名。
+// ODC 将 SQL Server 的 database.schema 平铺为 schema 名（如 TestDB.dbo），
+// 而 SQLE 直连审核会把 schema_name 当作连接的数据库名。
+func normalizeSQLEAuditSchemaName(dbType, schemaName string) string {
+	if dbType != string(pkgConst.DBTypeSQLServer) {
+		return schemaName
+	}
+	if idx := strings.Index(schemaName, "."); idx > 0 {
+		return schemaName[:idx]
+	}
+	return schemaName
+}
+
 // callSQLEAudit 调用 SQLE 直接审核接口
 func (sqlWorkbenchService *SqlWorkbenchService) callSQLEAudit(ctx context.Context, sql string, dbService *biz.DBService, schemaName string) (*cloudbeaver.AuditSQLReply, error) {
 	// 获取 SQLE 服务地址
@@ -1450,6 +1463,7 @@ func (sqlWorkbenchService *SqlWorkbenchService) callSQLEAudit(ctx context.Contex
 	}
 
 	sqleAddr := fmt.Sprintf("%s/v2/sql_audit", target.URL.String())
+	schemaName = normalizeSQLEAuditSchemaName(dbService.DBType, schemaName)
 
 	auditReq := cloudbeaver.AuditSQLReq{
 		InstanceType:     dbService.DBType,

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -367,3 +367,45 @@ func Test_buildOdcCreateAndUpdateRequests_setPasswordSaved(t *testing.T) {
 		t.Fatalf("expected passwordSaved in update JSON: %s", updateJSON)
 	}
 }
+
+func Test_normalizeSQLEAuditSchemaName(t *testing.T) {
+	cases := map[string]struct {
+		dbType   string
+		schema   string
+		expected string
+	}{
+		"SQL Server database.schema": {
+			dbType:   string(pkgConst.DBTypeSQLServer),
+			schema:   "TestDB.dbo",
+			expected: "TestDB",
+		},
+		"SQL Server catalog only": {
+			dbType:   string(pkgConst.DBTypeSQLServer),
+			schema:   "TestDB",
+			expected: "TestDB",
+		},
+		"SQL Server non-dbo schema": {
+			dbType:   string(pkgConst.DBTypeSQLServer),
+			schema:   "TestDB.sales",
+			expected: "TestDB",
+		},
+		"MySQL schema unchanged": {
+			dbType:   string(pkgConst.DBTypeMySQL),
+			schema:   "app.db",
+			expected: "app.db",
+		},
+		"Oracle schema unchanged": {
+			dbType:   string(pkgConst.DBTypeOracle),
+			schema:   "HR",
+			expected: "HR",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := normalizeSQLEAuditSchemaName(tc.dbType, tc.schema)
+			if got != tc.expected {
+				t.Fatalf("normalizeSQLEAuditSchemaName(%q, %q) = %q, want %q", tc.dbType, tc.schema, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### **User description**
## Summary

- 在 `callSQLEAudit` 前对 SQL Server 的 `schemaName` 做库名归一化：`TestDB.dbo` → `TestDB`
- 与 CloudBeaver 老路径使用 `DefaultCatalog` 的行为对齐，避免 SQLE 直连审核将 `TestDB.dbo` 当作数据库名连库失败

Fixes actiontech/dms-ee#911

## Problem

ODC 资源树将 SQL Server 的 `database.schema` 平铺为节点名（如 `TestDB.dbo`）。DMS 原样传给 SQLE `/v2/sql_audit` 的 `schema_name`，SQLE 将其赋给连接 DSN 的 `DatabaseName`，导致：

```
Cannot open database "TestDB.dbo" requested by the login.
```

## Test plan

- [x] `Test_normalizeSQLEAuditSchemaName` 覆盖 SQL Server / MySQL / Oracle

Made with [Cursor](https://cursor.com)


___

### **Description**
- 新增 normalizeSQLEAuditSchemaName 方法归一化 SQL Server schema 名称

- 在 callSQLEAudit 中调用归一化方法确保传递正确数据库名

- 新增单元测试覆盖多种数据库类型的归一化逻辑


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["调用 callSQLEAudit"]
  B["normalizeSQLEAuditSchemaName 函数"]
  C["返回正确的 catalog 名"]
  A -- "调用归一化" --> B
  B -- "返回规范化结果" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>新增 SQL Server schema 归一化方法及调用更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

<ul><li>新增 normalizeSQLEAuditSchemaName 方法处理 SQL Server schema 字符串<br> <li> 在 callSQLEAudit 中调用归一化方法传递正确数据库名称</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/644/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service_test.go</strong><dd><code>添加 SQL Server schema 归一化单元测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service_test.go

<ul><li>添加 Test_normalizeSQLEAuditSchemaName 单元测试验证归一化逻辑<br> <li> 覆盖 SQL Server、MySQL 和 Oracle 等场景</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/644/files#diff-f1262957293a3a114d62c6c25384b4b6ff3429052ff38b2ea648d687f79fdb08">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

