### PR TITLE
fix(sql_workbench): 对齐 ODC 与 CloudBeaver 数据源权限（业务写权关闭场景）

### DIFF
--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -540,8 +540,10 @@ func (sqlWorkbenchService *SqlWorkbenchService) getUserAccessibleDBServices(ctx 
 		return nil, fmt.Errorf("failed to get active db services: %v", err)
 	}
 
-	// 检查用户是否有全局权限
-	hasGlobalOpPermission, err := sqlWorkbenchService.opPermissionVerifyUsecase.CanOpGlobal(ctx, dmsUser.UID, false)
+	// 检查用户是否有全局权限。工作台数据源同步属于业务写场景，需传入 isBusinessWrite=true，
+	// 与 CloudBeaver 的 connectManagement 保持一致：系统管理员关闭业务写权后不再放行全部数据源，
+	// 而是走项目/数据源级权限过滤。
+	hasGlobalOpPermission, err := sqlWorkbenchService.opPermissionVerifyUsecase.CanOpGlobal(ctx, dmsUser.UID, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check global op permission: %v", err)
 	}


### PR DESCRIPTION
## 问题

超管关闭某用户的业务写权、并为其配置某数据源的项目角色（开发工程师）后：

- 使用 CloudBeaver 登录工作台仅可见该数据源（符合预期）
- 使用 ODC 登录工作台可见其他数据源且具备 SQL 执行能力（不符合预期）

预期 ODC 与 CloudBeaver 的数据源处理保持一致。

## 原因

ODC 同步数据源时 `getUserAccessibleDBServices` 调用 `CanOpGlobal(uid, false)`，未像 CloudBeaver 的 `connectManagement` 那样传入 `isBusinessWrite=true`。系统管理员在业务写权关闭时，`CanOpGlobal` 仍返回 `true`，跳过项目/数据源级过滤，导致 ODC 同步并可见全部活跃数据源；数据源一旦进入 ODC，审核中间件放行后即可执行 SQL。

## 修复

将 ODC 路径 `CanOpGlobal` 的 `isBusinessWrite` 参数改为 `true`，与 CloudBeaver 对齐。业务写权关闭的系统管理员改走项目/数据源级权限过滤，`cleanupObsoleteDatasources` 会清理此前多同步进 ODC 的数据源，使 ODC 与 CloudBeaver 数据源可见性一致。

## 关联 Issue

关联 actiontech/dms-ee#810 （系统管理员业务写权开关：关闭后应移出业务候选集、接口层拦截绕过 UI 的写操作）。本次修复补齐 ODC 工作台对该开关的落实。

## 测试计划

- [ ] 构造「系统管理员 + 关闭业务写权 + 某项目单数据源开发工程师」用户
- [ ] CloudBeaver 登录：仅可见该数据源
- [ ] 清除 ODC 会话或更换 token 后 ODC 登录：仅可见该数据源，且仅能对该数据源执行 SQL