### PR TITLE
fix(sql_workbench): enforce business write permission for auto workflow exec

### DIFF
--- a/internal/dms/biz/cloudbeaver.go
+++ b/internal/dms/biz/cloudbeaver.go
@@ -2060,7 +2060,11 @@ func (cu *CloudbeaverUsecase) getContextSchema(c echo.Context, connectionId, con
 // checkWorkflowPermission 校验用户是否有数据源上的"创建、审批、上线工单"的权限
 // 权限可以是项目级别的（项目管理员）或数据源级别的（直接针对数据源的工单权限）
 func (cu *CloudbeaverUsecase) checkWorkflowPermission(ctx context.Context, userUid string, dbService *DBService) (bool, error) {
-	if userUid == constant.UIDOfUserAdmin {
+	canOpGlobal, err := cu.opPermissionVerifyUsecase.CanOpGlobal(ctx, userUid, true)
+	if err != nil {
+		return false, fmt.Errorf("check global op permission err: %v", err)
+	}
+	if canOpGlobal {
 		return true, nil
 	}
 	opPermissions, err := cu.opPermissionVerifyUsecase.GetUserOpPermissionInProject(ctx, userUid, dbService.ProjectUID)

--- a/internal/sql_workbench/service/workflow_exec.go
+++ b/internal/sql_workbench/service/workflow_exec.go
@@ -81,7 +81,11 @@ func (sqlWorkbenchService *SqlWorkbenchService) shouldExecuteByWorkflow(dbServic
 }
 
 func (sqlWorkbenchService *SqlWorkbenchService) checkWorkflowPermission(ctx context.Context, userUID string, dbService *biz.DBService) (bool, error) {
-	if userUID == constant.UIDOfUserAdmin {
+	canOpGlobal, err := sqlWorkbenchService.opPermissionVerifyUsecase.CanOpGlobal(ctx, userUID, true)
+	if err != nil {
+		return false, fmt.Errorf("check global op permission err: %v", err)
+	}
+	if canOpGlobal {
 		return true, nil
 	}
 	opPermissions, err := sqlWorkbenchService.opPermissionVerifyUsecase.GetUserOpPermissionInProject(ctx, userUID, dbService.ProjectUID)


### PR DESCRIPTION
## Summary

Replace hardcoded admin bypass in ODC and CloudBeaver `checkWorkflowPermission` with `CanOpGlobal(..., isBusinessWrite=true)`. Global admins and sys users must have business write permission enabled before workbench non-DQL statements can auto-create and execute workflows. Other users still require project admin or create+audit+execute permissions on the target data source.

## Test plan

- [ ] Admin with BWP off rejected on non-DQL auto workflow exec (ODC + CB)
- [ ] Global admin with BWP on can auto exec
- [ ] Dev engineer (create only) rejected
- [ ] Project member with create+audit+execute on data source succeeds

Fixes actiontech/dms-ee#810
Related: actiontech/dms-ee#905