### PR TITLE
fix: PathEscape project name in DMS to SQLE URLs

### DIFF
--- a/internal/dms/biz/cloudbeaver.go
+++ b/internal/dms/biz/cloudbeaver.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 	"strings"
@@ -2341,13 +2342,13 @@ func (cu *CloudbeaverUsecase) AutoCreateAndExecuteWorkflow(ctx context.Context, 
 		return nil, fmt.Errorf("close multipart writer failed: %v", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/projects/%s/workflows/auto_create_and_execute", sqleUrl, projectName)
+	reqURL := fmt.Sprintf("%s/v1/projects/%s/workflows/auto_create_and_execute", sqleUrl, url.PathEscape(projectName))
 	headers := map[string]string{
 		"Authorization": pkgHttp.DefaultDMSToken,
 	}
 
 	var reply AutoCreateAndExecuteWorkflowRes
-	if err := pkgHttp.Call(ctx, http.MethodPost, url, headers, writer.FormDataContentType(), requestBody.Bytes(), &reply); err != nil {
+	if err := pkgHttp.Call(ctx, http.MethodPost, reqURL, headers, writer.FormDataContentType(), requestBody.Bytes(), &reply); err != nil {
 		return nil, fmt.Errorf("request sqle failed: %v", err)
 	}
 

--- a/internal/dms/biz/db_service.go
+++ b/internal/dms/biz/db_service.go
@@ -3,6 +3,7 @@ package biz
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
@@ -417,7 +418,7 @@ func (d *DBServiceUsecase) AddInstanceAuditPlanForDBServiceFromSqle(ctx context.
 	if err != nil {
 		return fmt.Errorf("get proxy target by name failed: %v", err)
 	}
-	sqleAddr := fmt.Sprintf("%s/v2/projects/%s/instance_audit_plans", target.URL.String(), project.Name)
+	sqleAddr := fmt.Sprintf("%s/v2/projects/%s/instance_audit_plans", target.URL.String(), url.PathEscape(project.Name))
 	header := map[string]string{
 		"Authorization":           pkgHttp.DefaultDMSToken,
 		i18nPkg.AcceptLanguageKey: locale.Bundle.GetLangTagFromCtx(ctx).String(),

--- a/internal/sql_workbench/service/workflow_exec.go
+++ b/internal/sql_workbench/service/workflow_exec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -181,12 +182,12 @@ func (sqlWorkbenchService *SqlWorkbenchService) autoCreateAndExecuteWorkflow(ctx
 		return nil, fmt.Errorf("close multipart writer failed: %v", err)
 	}
 
-	url := fmt.Sprintf("%s/v1/projects/%s/workflows/auto_create_and_execute", sqleURL, projectName)
+	reqURL := fmt.Sprintf("%s/v1/projects/%s/workflows/auto_create_and_execute", sqleURL, url.PathEscape(projectName))
 	headers := map[string]string{
 		"Authorization": pkgHttp.DefaultDMSToken,
 	}
 	var reply autoCreateAndExecuteWorkflowRes
-	if err := pkgHttp.Call(ctx, http.MethodPost, url, headers, writer.FormDataContentType(), requestBody.Bytes(), &reply); err != nil {
+	if err := pkgHttp.Call(ctx, http.MethodPost, reqURL, headers, writer.FormDataContentType(), requestBody.Bytes(), &reply); err != nil {
 		return nil, fmt.Errorf("request sqle failed: %v", err)
 	}
 	if reply.Code != 0 {


### PR DESCRIPTION
### **User description**
## Summary
- PathEscape `project_name` when DMS builds SQLE URLs that place the name in the path (`db_service`, CloudBeaver auto workflow, SQL Workbench auto workflow).
- Enables Chinese project names for downstream SQLE calls from DMS.

## Test plan
- [x] Static scan: all DMS hard-coded project-name SQLE URLs use PathEscape
- [x] Gateway matrix: FE SQLE family routes with encoded Chinese project_name
- [x] Chromium wire encode check for Chinese project_name paths
- [x] Create Chinese-named project via API on quick-deploy

Fixes actiontech/dms-ee#936


___

### **Description**
- 使用 url.PathEscape 对项目名称进行编码

- 更新 Cloudbeaver、DBService 与 Workbench 相关 URL 构建方式

- 确保中文项目名称在 SQLE 调用中正确传递


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["“项目名称”未编码"] --> B["调用 url.PathEscape 进行编码"]
  B --> C["生成安全 URL"]
  C --> D["下游 SQLE API 调用"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloudbeaver.go</strong><dd><code>Cloudbeaver 项目名称 URL 编码更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/biz/cloudbeaver.go

<ul><li>引入 "net/url" 包<br> <li> 使用 url.PathEscape 对 projectName 进行编码<br> <li> 替换变量名从 url 到 reqURL</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/653/files#diff-87b08a1658e7e3f486c31d72330f59fb08325ea86ca6de55bdf91668d7277e51">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>db_service.go</strong><dd><code>DBService 项目名称 URL 编码更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/biz/db_service.go

<ul><li>添加 "net/url" 包的引用<br> <li> 使用 url.PathEscape 对 project.Name 编码构建 URL<br> <li> 修复实例审核计划的 URL 构造问题</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/653/files#diff-f2549b95bfd4a21a4d3c5e980b7da73ea64a00c4395b5fefffce87686be3a310">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workflow_exec.go</strong><dd><code>SQL Workbench 项目名称 URL 编码更新</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/workflow_exec.go

<ul><li>引入 "net/url" 包<br> <li> 采用 url.PathEscape 对 projectName 进行编码<br> <li> 修改变量名从 url 到 reqURL，确保接口调用正常</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/653/files#diff-bfa1b63dfbf87036daab30fef1d637da991c8065d957f3233eae0529854843e6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

