### PR TITLE
feat: DMS↔ODC 用户同步自愈（策略 A+B）

### DIFF
--- a/internal/apiserver/service/router.go
+++ b/internal/apiserver/service/router.go
@@ -532,6 +532,9 @@ func (s *APIServer) installController() error {
 	}
 	s.SqlWorkbenchController.SqlWorkbenchService.SetSqlResultMasker(masker)
 
+	// 策略 B：DMS 删用户时清理 SqlWorkbench 缓存/会话并禁用 ODC 对应用户
+	s.DMSController.DMS.UserUsecase.SetSqlWorkbenchLifecycle(s.SqlWorkbenchController.SqlWorkbenchService)
+
 	// s.AuthController.RegisterPlugin(s.DMSController.GetRegisterPluginFn())
 	return nil
 }

--- a/internal/dms/biz/user.go
+++ b/internal/dms/biz/user.go
@@ -217,6 +217,7 @@ type SqlWorkbenchUser struct {
 type SqlWorkbenchUserRepo interface {
 	GetSqlWorkbenchUserByDMSUserID(ctx context.Context, dmsUserID string) (*SqlWorkbenchUser, bool, error)
 	SaveSqlWorkbenchUserCache(ctx context.Context, user *SqlWorkbenchUser) error
+	DeleteSqlWorkbenchUserCache(ctx context.Context, dmsUserID string) error
 }
 
 // SqlWorkbenchDatasource SqlWorkbench数据源缓存
@@ -233,7 +234,13 @@ type SqlWorkbenchDatasourceRepo interface {
 	GetSqlWorkbenchDatasourceByDMSDBServiceID(ctx context.Context, dmsDBServiceID, dmsUserID, purpose string) (*SqlWorkbenchDatasource, bool, error)
 	SaveSqlWorkbenchDatasourceCache(ctx context.Context, datasource *SqlWorkbenchDatasource) error
 	DeleteSqlWorkbenchDatasourceCache(ctx context.Context, dmsDBServiceID, dmsUserID, purpose string) error
+	DeleteSqlWorkbenchDatasourceCachesByUserID(ctx context.Context, dmsUserID string) error
 	GetSqlWorkbenchDatasourcesByUserID(ctx context.Context, dmsUserID string) ([]*SqlWorkbenchDatasource, error)
+}
+
+// SqlWorkbenchLifecycle 删除 DMS 用户时的 SqlWorkbench/ODC 生命周期清理（策略 B）
+type SqlWorkbenchLifecycle interface {
+	CleanupOnDMSUserDelete(ctx context.Context, dmsUserID, dmsUserName string) error
 }
 
 type UserUsecase struct {
@@ -247,7 +254,13 @@ type UserUsecase struct {
 	ldapConfigurationUsecase  *LDAPConfigurationUsecase
 	cloudBeaverRepo           CloudbeaverRepo
 	gatewayUsecase            *GatewayUsecase
+	sqlWorkbenchLifecycle     SqlWorkbenchLifecycle
 	log                       *utilLog.Helper
+}
+
+// SetSqlWorkbenchLifecycle 注入策略 B 清理能力（由 apiserver 在 SqlWorkbenchService 就绪后接线）
+func (d *UserUsecase) SetSqlWorkbenchLifecycle(lifecycle SqlWorkbenchLifecycle) {
+	d.sqlWorkbenchLifecycle = lifecycle
 }
 
 func NewUserUsecase(log utilLog.Logger, tx TransactionGenerator, repo UserRepo, userGroupRepo UserGroupRepo, pluginUsecase *PluginUsecase, opPermissionUsecase *OpPermissionUsecase,
@@ -717,6 +730,13 @@ func (d *UserUsecase) DelUser(ctx context.Context, currentUserUid, UserUid strin
 
 	if err := d.cloudBeaverRepo.DeleteAllCloudbeaverCachesByUserId(tx, UserUid); nil != err {
 		return fmt.Errorf("delete cloudbeaver cache failed: %v", err)
+	}
+
+	// 策略 B：清 SqlWorkbench 缓存 + 会话，并对 ODC 对应用户禁用（ODC 失败不阻断）
+	if d.sqlWorkbenchLifecycle != nil {
+		if err := d.sqlWorkbenchLifecycle.CleanupOnDMSUserDelete(tx, UserUid, ds.Name); err != nil {
+			return fmt.Errorf("delete sql workbench cache failed: %v", err)
+		}
 	}
 
 	if err := d.repo.DelUser(tx, UserUid); nil != err {

--- a/internal/dms/storage/sql_workbench.go
+++ b/internal/dms/storage/sql_workbench.go
@@ -45,6 +45,15 @@ func (sr *SqlWorkbenchRepo) SaveSqlWorkbenchUserCache(ctx context.Context, user 
 	})
 }
 
+func (sr *SqlWorkbenchRepo) DeleteSqlWorkbenchUserCache(ctx context.Context, dmsUserID string) error {
+	return transaction(sr.log, ctx, sr.db, func(tx *gorm.DB) error {
+		if err := tx.WithContext(ctx).Where("dms_user_id = ?", dmsUserID).Delete(&model.SqlWorkbenchUserCache{}).Error; err != nil {
+			return fmt.Errorf("failed to delete sql workbench user cache: %v", err)
+		}
+		return nil
+	})
+}
+
 func convertModelSqlWorkbenchUser(user *model.SqlWorkbenchUserCache) *biz.SqlWorkbenchUser {
 	return &biz.SqlWorkbenchUser{
 		DMSUserID:            user.DMSUserID,
@@ -105,6 +114,15 @@ func (sr *SqlWorkbenchDatasourceRepo) DeleteSqlWorkbenchDatasourceCache(ctx cont
 	return transaction(sr.log, ctx, sr.db, func(tx *gorm.DB) error {
 		if err := tx.WithContext(ctx).Where("dms_db_service_id = ? AND dms_user_id = ? AND purpose = ?", dmsDBServiceID, dmsUserID, purpose).Delete(&model.SqlWorkbenchDatasourceCache{}).Error; err != nil {
 			return fmt.Errorf("failed to delete sql workbench datasource cache: %v", err)
+		}
+		return nil
+	})
+}
+
+func (sr *SqlWorkbenchDatasourceRepo) DeleteSqlWorkbenchDatasourceCachesByUserID(ctx context.Context, dmsUserID string) error {
+	return transaction(sr.log, ctx, sr.db, func(tx *gorm.DB) error {
+		if err := tx.WithContext(ctx).Where("dms_user_id = ?", dmsUserID).Delete(&model.SqlWorkbenchDatasourceCache{}).Error; err != nil {
+			return fmt.Errorf("failed to delete sql workbench datasource caches by user id: %v", err)
 		}
 		return nil
 	})

--- a/internal/sql_workbench/client/sql_workbench_client.go
+++ b/internal/sql_workbench/client/sql_workbench_client.go
@@ -7,10 +7,12 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -612,14 +614,19 @@ func (c *SqlWorkbenchClient) CreateUsers(users []CreateUserRequest, publicKey st
 		return nil, fmt.Errorf("failed to read create users response: %v", err)
 	}
 
+	var createUsersResp CreateUsersResponse
+	_ = json.Unmarshal(body, &createUsersResp)
+
 	// 检查HTTP状态码
 	if resp.StatusCode != http.StatusOK {
 		c.log.Errorf("Create users failed with status code: %d, response: %s", resp.StatusCode, string(body))
+		if isCreateUsersDuplicatedResponse(resp.StatusCode, body, &createUsersResp) {
+			return nil, newCreateUsersConflictError(resp.StatusCode, &createUsersResp, body)
+		}
 		return nil, fmt.Errorf("create users failed with status code: %d", resp.StatusCode)
 	}
 
-	// 解析响应
-	var createUsersResp CreateUsersResponse
+	// 解析响应（HTTP 200 时要求结构合法）
 	if err := json.Unmarshal(body, &createUsersResp); err != nil {
 		c.log.Errorf("Failed to parse create users response: %v", err)
 		return nil, fmt.Errorf("failed to parse create users response: %v", err)
@@ -632,11 +639,239 @@ func (c *SqlWorkbenchClient) CreateUsers(users []CreateUserRequest, publicKey st
 			errorMsg = *createUsersResp.Message
 		}
 		c.log.Errorf("Create users failed: %s", errorMsg)
+		if isCreateUsersDuplicatedResponse(resp.StatusCode, body, &createUsersResp) {
+			return nil, newCreateUsersConflictError(resp.StatusCode, &createUsersResp, body)
+		}
 		return nil, fmt.Errorf("create users failed: %s", errorMsg)
 	}
 
 	c.log.Infof("Successfully created %d users", len(createUsersResp.Data.Contents))
 	return &createUsersResp, nil
+}
+
+// CreateUsersConflictError 表示 ODC 侧账号已存在冲突，调用方可走再查绑定兜底
+type CreateUsersConflictError struct {
+	StatusCode int
+	Code       string
+	Message    string
+}
+
+func (e *CreateUsersConflictError) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("create users conflict: %s", e.Message)
+	}
+	if e.Code != "" {
+		return fmt.Sprintf("create users conflict: code=%s status=%d", e.Code, e.StatusCode)
+	}
+	return fmt.Sprintf("create users conflict: status=%d", e.StatusCode)
+}
+
+// IsCreateUsersConflict 判断错误是否为账号已存在冲突
+func IsCreateUsersConflict(err error) bool {
+	var conflict *CreateUsersConflictError
+	return errors.As(err, &conflict)
+}
+
+func newCreateUsersConflictError(statusCode int, resp *CreateUsersResponse, body []byte) *CreateUsersConflictError {
+	err := &CreateUsersConflictError{StatusCode: statusCode}
+	if resp != nil {
+		if resp.Code != nil {
+			err.Code = *resp.Code
+		}
+		if resp.Message != nil {
+			err.Message = *resp.Message
+		}
+	}
+	if err.Message == "" {
+		err.Message = string(body)
+	}
+	return err
+}
+
+func isCreateUsersDuplicatedResponse(statusCode int, body []byte, resp *CreateUsersResponse) bool {
+	bodyStr := string(body)
+	if resp != nil && resp.Code != nil && strings.Contains(*resp.Code, "DuplicatedExists") {
+		return true
+	}
+	if strings.Contains(bodyStr, "DuplicatedExists") {
+		return true
+	}
+	if resp != nil && resp.Message != nil {
+		msg := *resp.Message
+		if strings.Contains(msg, "已存在") || strings.Contains(strings.ToLower(msg), "already exist") {
+			return true
+		}
+	}
+	if strings.Contains(bodyStr, "已存在") {
+		return true
+	}
+	_ = statusCode
+	return false
+}
+
+// ListUsers 按 accountName 查询 ODC 用户列表
+func (c *SqlWorkbenchClient) ListUsers(accountName string, cookie string) (*ListUsersResponse, error) {
+	c.log.Infof("Attempting to list users by accountName: %s", accountName)
+
+	listUsersURL := fmt.Sprintf("%s/api/v2/iam/users?accountName=%s&currentOrganizationId=1&size=100",
+		c.baseURL, url.QueryEscape(accountName))
+
+	req, err := http.NewRequest("GET", listUsersURL, nil)
+	if err != nil {
+		c.log.Errorf("Failed to create list users request: %v", err)
+		return nil, fmt.Errorf("failed to create list users request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", cookie)
+	req.Header.Set("X-Xsrf-Token", c.ExtractCookieValue(cookie, "XSRF-TOKEN"))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.log.Errorf("Failed to send list users request: %v", err)
+		return nil, fmt.Errorf("failed to send list users request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		c.log.Errorf("Failed to read list users response: %v", err)
+		return nil, fmt.Errorf("failed to read list users response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		c.log.Errorf("List users failed with status code: %d, response: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("list users failed with status code: %d", resp.StatusCode)
+	}
+
+	var listUsersResp ListUsersResponse
+	if err := json.Unmarshal(body, &listUsersResp); err != nil {
+		c.log.Errorf("Failed to parse list users response: %v", err)
+		return nil, fmt.Errorf("failed to parse list users response: %v", err)
+	}
+
+	if !listUsersResp.Successful {
+		errorMsg := "list users failed"
+		if listUsersResp.Message != nil {
+			errorMsg = *listUsersResp.Message
+		}
+		c.log.Errorf("List users failed: %s", errorMsg)
+		return nil, fmt.Errorf("list users failed: %s", errorMsg)
+	}
+
+	c.log.Infof("Successfully listed %d users for accountName %s", len(listUsersResp.Data.Contents), accountName)
+	return &listUsersResp, nil
+}
+
+// SetUserEnabled 启用或禁用 ODC 用户
+func (c *SqlWorkbenchClient) SetUserEnabled(userID int64, enabled bool, cookie string) (*SetUserEnabledResponse, error) {
+	c.log.Infof("Attempting to set user enabled=%v for id=%d", enabled, userID)
+
+	setEnabledURL := fmt.Sprintf("%s/api/v2/iam/users/%d/setEnabled?currentOrganizationId=1", c.baseURL, userID)
+	payload := SetEnabledRequest{Enabled: enabled}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal setEnabled request: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", setEnabledURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create setEnabled request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", cookie)
+	req.Header.Set("X-Xsrf-Token", c.ExtractCookieValue(cookie, "XSRF-TOKEN"))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.log.Errorf("Failed to send setEnabled request: %v", err)
+		return nil, fmt.Errorf("failed to send setEnabled request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read setEnabled response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		c.log.Errorf("setEnabled failed with status code: %d, response: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("setEnabled failed with status code: %d", resp.StatusCode)
+	}
+
+	var setEnabledResp SetUserEnabledResponse
+	if err := json.Unmarshal(body, &setEnabledResp); err != nil {
+		return nil, fmt.Errorf("failed to parse setEnabled response: %v", err)
+	}
+	if !setEnabledResp.Successful {
+		errorMsg := "setEnabled failed"
+		if setEnabledResp.Message != nil {
+			errorMsg = *setEnabledResp.Message
+		}
+		return nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	c.log.Infof("Successfully set user enabled=%v for id=%d", enabled, userID)
+	return &setEnabledResp, nil
+}
+
+// ResetUserPassword 管理员重置用户密码（newPassword 明文，内部 RSA 加密）
+func (c *SqlWorkbenchClient) ResetUserPassword(userID int64, newPassword, publicKey, cookie string) (*ResetUserPasswordResponse, error) {
+	c.log.Infof("Attempting to reset password for user id=%d", userID)
+
+	encryptedPassword, err := c.EncryptPasswordWithRSA(newPassword, publicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encrypt new password: %v", err)
+	}
+
+	resetURL := fmt.Sprintf("%s/api/v2/iam/users/resetPassword?id=%d&currentOrganizationId=1", c.baseURL, userID)
+	payload := ResetPasswordRequest{NewPassword: encryptedPassword}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal resetPassword request: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", resetURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resetPassword request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Cookie", cookie)
+	req.Header.Set("X-Xsrf-Token", c.ExtractCookieValue(cookie, "XSRF-TOKEN"))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		c.log.Errorf("Failed to send resetPassword request: %v", err)
+		return nil, fmt.Errorf("failed to send resetPassword request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read resetPassword response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		c.log.Errorf("resetPassword failed with status code: %d, response: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("resetPassword failed with status code: %d", resp.StatusCode)
+	}
+
+	var resetResp ResetUserPasswordResponse
+	if err := json.Unmarshal(body, &resetResp); err != nil {
+		return nil, fmt.Errorf("failed to parse resetPassword response: %v", err)
+	}
+	if !resetResp.Successful {
+		errorMsg := "resetPassword failed"
+		if resetResp.Message != nil {
+			errorMsg = *resetResp.Message
+		}
+		return nil, fmt.Errorf("%s", errorMsg)
+	}
+
+	c.log.Infof("Successfully reset password for user id=%d", userID)
+	return &resetResp, nil
 }
 
 // ActivateUser 激活用户
@@ -919,6 +1154,63 @@ type CreateUsersResponse struct {
 	Code    *string     `json:"code,omitempty"`
 	Message *string     `json:"message,omitempty"`
 	Error   interface{} `json:"error,omitempty"`
+}
+
+// ListUsersResponse 查询用户列表响应
+type ListUsersResponse struct {
+	Data struct {
+		Contents []User `json:"contents"`
+	} `json:"data"`
+	DurationMillis int64   `json:"durationMillis"`
+	HTTPStatus     string  `json:"httpStatus"`
+	RequestID      string  `json:"requestId"`
+	Server         string  `json:"server"`
+	Successful     bool    `json:"successful"`
+	Timestamp      float64 `json:"timestamp"`
+	TraceID        string  `json:"traceId"`
+	Code           *string `json:"code,omitempty"`
+	Message        *string `json:"message,omitempty"`
+	Error          interface{} `json:"error,omitempty"`
+}
+
+// SetEnabledRequest 启用/禁用用户请求
+type SetEnabledRequest struct {
+	Enabled bool `json:"enabled"`
+}
+
+// SetUserEnabledResponse 启用/禁用用户响应
+type SetUserEnabledResponse struct {
+	Data           User    `json:"data"`
+	DurationMillis int64   `json:"durationMillis"`
+	HTTPStatus     string  `json:"httpStatus"`
+	RequestID      string  `json:"requestId"`
+	Server         string  `json:"server"`
+	Successful     bool    `json:"successful"`
+	Timestamp      float64 `json:"timestamp"`
+	TraceID        string  `json:"traceId"`
+	Code           *string `json:"code,omitempty"`
+	Message        *string `json:"message,omitempty"`
+	Error          interface{} `json:"error,omitempty"`
+}
+
+// ResetPasswordRequest 管理员重置密码请求
+type ResetPasswordRequest struct {
+	NewPassword string `json:"newPassword"`
+}
+
+// ResetUserPasswordResponse 管理员重置密码响应
+type ResetUserPasswordResponse struct {
+	Data           User    `json:"data"`
+	DurationMillis int64   `json:"durationMillis"`
+	HTTPStatus     string  `json:"httpStatus"`
+	RequestID      string  `json:"requestId"`
+	Server         string  `json:"server"`
+	Successful     bool    `json:"successful"`
+	Timestamp      float64 `json:"timestamp"`
+	TraceID        string  `json:"traceId"`
+	Code           *string `json:"code,omitempty"`
+	Message        *string `json:"message,omitempty"`
+	Error          interface{} `json:"error,omitempty"`
 }
 
 // Organization 组织结构

--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -62,7 +62,15 @@ type odcSession struct {
 var (
 	dmsUserIdODCSessionMap = make(map[string]odcSession)
 	odcSessionMutex        = &sync.Mutex{}
+	ensureUserLocks        sync.Map // accountName -> *sync.Mutex，串行化同账号 ensure，避免并发重置密码
 )
+
+func lockEnsureSqlWorkbenchUser(accountName string) func() {
+	v, _ := ensureUserLocks.LoadOrStore(accountName, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	mu.Lock()
+	return mu.Unlock
+}
 
 // generateSqlWorkbenchUsername 生成 SQL Workbench 用户名
 func (s *SqlWorkbenchService) generateSqlWorkbenchUsername(dmsUserName string) string {
@@ -283,14 +291,14 @@ func (sqlWorkbenchService *SqlWorkbenchService) Login() echo.MiddlewareFunc {
 				return err
 			}
 
-			// 3. 如果用户不存在，调用sqlworkbench创建用户接口进行创建
+			// 3. 缓存未命中：策略 A — 先查 ODC 再创建，冲突再查绑定
 			if !exists {
-				err = sqlWorkbenchService.createSqlWorkbenchUser(c.Request().Context(), user)
+				err = sqlWorkbenchService.ensureSqlWorkbenchUser(c.Request().Context(), user)
 				if err != nil {
-					sqlWorkbenchService.log.Errorf("Failed to create sql workbench user: %v", err)
+					sqlWorkbenchService.log.Errorf("Failed to ensure sql workbench user: %v", err)
 					return err
 				}
-				// 重新获取创建后的用户信息
+				// 重新获取绑定/创建后的用户信息
 				sqlWorkbenchUser, _, err = sqlWorkbenchService.sqlWorkbenchUserRepo.GetSqlWorkbenchUserByDMSUserID(c.Request().Context(), dmsUserId)
 				if err != nil {
 					sqlWorkbenchService.log.Errorf("Failed to get created sql workbench user: %v", err)
@@ -320,18 +328,29 @@ func (sqlWorkbenchService *SqlWorkbenchService) Login() echo.MiddlewareFunc {
 	}
 }
 
-// createSqlWorkbenchUser 创建SqlWorkbench用户
-func (sqlWorkbenchService *SqlWorkbenchService) createSqlWorkbenchUser(ctx context.Context, dmsUser *biz.User) error {
+// ensureSqlWorkbenchUser 策略 A：映射缺失时先查 ODC，命中则复用绑定；无则创建；创建冲突再查绑定
+func (sqlWorkbenchService *SqlWorkbenchService) ensureSqlWorkbenchUser(ctx context.Context, dmsUser *biz.User) error {
+	accountName := sqlWorkbenchService.generateSqlWorkbenchUsername(dmsUser.Name)
+	unlock := lockEnsureSqlWorkbenchUser(accountName)
+	defer unlock()
+
 	cookie, _, publicKey, err := sqlWorkbenchService.getUserCookie(sqlWorkbenchService.cfg.AdminUser, sqlWorkbenchService.cfg.AdminPassword)
 	if err != nil {
 		return err
 	}
 
-	// 创建用户请求
-	sqlWorkbenchUsername := sqlWorkbenchService.generateSqlWorkbenchUsername(dmsUser.Name)
+	odcUser, err := sqlWorkbenchService.findExactSqlWorkbenchUser(accountName, cookie)
+	if err != nil {
+		return err
+	}
+	if odcUser != nil {
+		sqlWorkbenchService.log.Infof("Found existing sql workbench user %s (ID: %d), binding for DMS user %s", accountName, odcUser.ID, dmsUser.Name)
+		return sqlWorkbenchService.bindExistingSqlWorkbenchUser(ctx, dmsUser, odcUser, publicKey, cookie)
+	}
+
 	createUserReq := []client.CreateUserRequest{
 		{
-			AccountName: sqlWorkbenchUsername,
+			AccountName: accountName,
 			Name:        dmsUser.Name,
 			Password:    SQL_WORKBENCH_DEFAULT_PASSWORD,
 			Enabled:     true,
@@ -339,9 +358,22 @@ func (sqlWorkbenchService *SqlWorkbenchService) createSqlWorkbenchUser(ctx conte
 		},
 	}
 
-	// 调用创建用户接口
 	createUserResp, err := sqlWorkbenchService.client.CreateUsers(createUserReq, publicKey, cookie)
 	if err != nil {
+		// 冲突（DuplicatedExists）或并发创建写冲突（如 DataAccessError）：再查绑定
+		sqlWorkbenchService.log.Infof("Create sql workbench user failed for %s: %v; re-list and try bind", accountName, err)
+		odcUser, listErr := sqlWorkbenchService.findExactSqlWorkbenchUser(accountName, cookie)
+		if listErr != nil {
+			return fmt.Errorf("failed to create user in sql workbench: %v (re-list: %v)", err, listErr)
+		}
+		if odcUser != nil {
+			if client.IsCreateUsersConflict(err) {
+				sqlWorkbenchService.log.Infof("Create conflict for %s, binding existing user", accountName)
+			} else {
+				sqlWorkbenchService.log.Infof("Create failed but user %s now exists, binding", accountName)
+			}
+			return sqlWorkbenchService.bindExistingSqlWorkbenchUser(ctx, dmsUser, odcUser, publicKey, cookie)
+		}
 		return fmt.Errorf("failed to create user in sql workbench: %v", err)
 	}
 
@@ -349,9 +381,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) createSqlWorkbenchUser(ctx conte
 		return fmt.Errorf("no user created in sql workbench")
 	}
 
-	// 激活用户
 	activateUserResp, err := sqlWorkbenchService.client.ActivateUser(
-		sqlWorkbenchService.generateSqlWorkbenchUsername(dmsUser.Name),
+		accountName,
 		SQL_WORKBENCH_DEFAULT_PASSWORD,
 		SQL_WORKBENCH_REAL_PASSWORD,
 		publicKey,
@@ -361,20 +392,97 @@ func (sqlWorkbenchService *SqlWorkbenchService) createSqlWorkbenchUser(ctx conte
 		return fmt.Errorf("failed to activate user in sql workbench: %v", err)
 	}
 
-	// 保存用户缓存
 	sqlWorkbenchUser := &biz.SqlWorkbenchUser{
-		SqlWorkbenchUsername: sqlWorkbenchService.generateSqlWorkbenchUsername(dmsUser.Name),
+		SqlWorkbenchUsername: accountName,
 		DMSUserID:            dmsUser.UID,
 		SqlWorkbenchUserId:   activateUserResp.Data.ID,
 	}
-
-	err = sqlWorkbenchService.sqlWorkbenchUserRepo.SaveSqlWorkbenchUserCache(ctx, sqlWorkbenchUser)
-	if err != nil {
+	if err = sqlWorkbenchService.sqlWorkbenchUserRepo.SaveSqlWorkbenchUserCache(ctx, sqlWorkbenchUser); err != nil {
 		return fmt.Errorf("failed to save sql workbench user cache: %v", err)
 	}
 
 	sqlWorkbenchService.log.Infof("Successfully created and activated sql workbench user for DMS user %s (ID: %d)", dmsUser.Name, activateUserResp.Data.ID)
 	return nil
+}
+
+// findExactSqlWorkbenchUser 按 accountName 精确匹配；0 返回 nil；>1 硬失败
+func (sqlWorkbenchService *SqlWorkbenchService) findExactSqlWorkbenchUser(accountName, cookie string) (*client.User, error) {
+	listResp, err := sqlWorkbenchService.client.ListUsers(accountName, cookie)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list sql workbench users: %v", err)
+	}
+
+	matches := make([]client.User, 0)
+	for _, u := range listResp.Data.Contents {
+		if u.AccountName == accountName {
+			matches = append(matches, u)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, nil
+	case 1:
+		user := matches[0]
+		return &user, nil
+	default:
+		return nil, fmt.Errorf("ambiguous sql workbench users for accountName %s: found %d", accountName, len(matches))
+	}
+}
+
+// bindExistingSqlWorkbenchUser 复用已有 ODC 账户：ensureUsable 后写本地映射
+func (sqlWorkbenchService *SqlWorkbenchService) bindExistingSqlWorkbenchUser(ctx context.Context, dmsUser *biz.User, odcUser *client.User, publicKey, cookie string) error {
+	if err := sqlWorkbenchService.ensureSqlWorkbenchUserUsable(odcUser, publicKey, cookie); err != nil {
+		return err
+	}
+
+	sqlWorkbenchUser := &biz.SqlWorkbenchUser{
+		SqlWorkbenchUsername: sqlWorkbenchService.generateSqlWorkbenchUsername(dmsUser.Name),
+		DMSUserID:            dmsUser.UID,
+		SqlWorkbenchUserId:   odcUser.ID,
+	}
+	if err := sqlWorkbenchService.sqlWorkbenchUserRepo.SaveSqlWorkbenchUserCache(ctx, sqlWorkbenchUser); err != nil {
+		return fmt.Errorf("failed to save sql workbench user cache: %v", err)
+	}
+
+	sqlWorkbenchService.log.Infof("Successfully bound existing sql workbench user %s (ID: %d) for DMS user %s", sqlWorkbenchUser.SqlWorkbenchUsername, odcUser.ID, dmsUser.Name)
+	return nil
+}
+
+// ensureSqlWorkbenchUserUsable 启用（若禁用）并强制对齐代管登录密码。
+// ODC admin resetPassword 会将 active 置为 false，故先重置为 DEFAULT 再 Activate(DEFAULT→REAL)，
+// 最终密码为 SQL_WORKBENCH_REAL_PASSWORD 且账户可用（与新建路径一致）。
+// 若代管密码已可登录则跳过重置，避免并发绑定互相踩密码。
+func (sqlWorkbenchService *SqlWorkbenchService) ensureSqlWorkbenchUserUsable(odcUser *client.User, publicKey, cookie string) error {
+	if !odcUser.Enabled {
+		if _, err := sqlWorkbenchService.client.SetUserEnabled(odcUser.ID, true, cookie); err != nil {
+			return fmt.Errorf("failed to enable sql workbench user: %v", err)
+		}
+	}
+
+	if _, err := sqlWorkbenchService.client.Login(odcUser.AccountName, SQL_WORKBENCH_REAL_PASSWORD, publicKey); err == nil {
+		sqlWorkbenchService.log.Infof("sql workbench user %s already usable with managed password, skip reset", odcUser.AccountName)
+		return nil
+	}
+
+	if _, err := sqlWorkbenchService.client.ResetUserPassword(odcUser.ID, SQL_WORKBENCH_DEFAULT_PASSWORD, publicKey, cookie); err != nil {
+		return fmt.Errorf("failed to reset sql workbench user password: %v", err)
+	}
+
+	if _, err := sqlWorkbenchService.client.ActivateUser(
+		odcUser.AccountName,
+		SQL_WORKBENCH_DEFAULT_PASSWORD,
+		SQL_WORKBENCH_REAL_PASSWORD,
+		publicKey,
+		cookie,
+	); err != nil {
+		return fmt.Errorf("failed to activate sql workbench user after password reset: %v", err)
+	}
+	return nil
+}
+
+// createSqlWorkbenchUser 保留为 ensure 新建路径的语义别名（测试/兼容调用）
+func (sqlWorkbenchService *SqlWorkbenchService) createSqlWorkbenchUser(ctx context.Context, dmsUser *biz.User) error {
+	return sqlWorkbenchService.ensureSqlWorkbenchUser(ctx, dmsUser)
 }
 
 // loginSqlWorkbenchUser 使用SqlWorkbench用户登录并设置Cookie
@@ -460,6 +568,80 @@ func (sqlWorkbenchService *SqlWorkbenchService) clearODCSession(dmsUserId string
 	defer odcSessionMutex.Unlock()
 
 	delete(dmsUserIdODCSessionMap, dmsUserId)
+}
+
+// CleanupOnDMSUserDelete 策略 B：删除 DMS 用户时清理 SqlWorkbench 缓存/会话并对 ODC 用户禁用（非删除）
+// B1–B3 缓存失败返回 error（阻断 DMS 删除）；B4 忽略不存在；B5 ODC 禁用失败仅记日志不返回 error。
+func (sqlWorkbenchService *SqlWorkbenchService) CleanupOnDMSUserDelete(ctx context.Context, dmsUserID, dmsUserName string) error {
+	// B1: 读用户缓存（记下 ODC user id，供 B5）
+	cachedUser, _, err := sqlWorkbenchService.sqlWorkbenchUserRepo.GetSqlWorkbenchUserByDMSUserID(ctx, dmsUserID)
+	if err != nil {
+		return fmt.Errorf("get sql workbench user cache failed: %v", err)
+	}
+
+	var odcUserID int64
+	var odcUsername string
+	if cachedUser != nil {
+		odcUserID = cachedUser.SqlWorkbenchUserId
+		odcUsername = cachedUser.SqlWorkbenchUsername
+	}
+
+	// B2: 删数据源缓存
+	if err := sqlWorkbenchService.sqlWorkbenchDatasourceRepo.DeleteSqlWorkbenchDatasourceCachesByUserID(ctx, dmsUserID); err != nil {
+		return fmt.Errorf("delete sql workbench datasource caches failed: %v", err)
+	}
+
+	// B3: 删用户缓存
+	if err := sqlWorkbenchService.sqlWorkbenchUserRepo.DeleteSqlWorkbenchUserCache(ctx, dmsUserID); err != nil {
+		return fmt.Errorf("delete sql workbench user cache failed: %v", err)
+	}
+
+	// B4: 清内存会话
+	sqlWorkbenchService.clearODCSession(dmsUserID)
+
+	// B5: ODC 禁用（失败不阻断）
+	sqlWorkbenchService.disableODCUserOnDMSDelete(odcUserID, odcUsername, dmsUserName)
+
+	sqlWorkbenchService.log.Infof("SqlWorkbench cleanup on DMS user delete done: dmsUserId=%s name=%s", dmsUserID, dmsUserName)
+	return nil
+}
+
+// disableODCUserOnDMSDelete 对 ODC 对应用户执行 setEnabled(false)；任何失败只记日志
+func (sqlWorkbenchService *SqlWorkbenchService) disableODCUserOnDMSDelete(odcUserID int64, cachedUsername, dmsUserName string) {
+	if !sqlWorkbenchService.IsConfigured() || sqlWorkbenchService.client == nil {
+		sqlWorkbenchService.log.Infof("SqlWorkbench not configured, skip ODC disable for DMS user %s", dmsUserName)
+		return
+	}
+
+	cookie, _, _, err := sqlWorkbenchService.getUserCookie(sqlWorkbenchService.cfg.AdminUser, sqlWorkbenchService.cfg.AdminPassword)
+	if err != nil {
+		sqlWorkbenchService.log.Errorf("ODC disable skipped: admin login failed for DMS user %s: %v", dmsUserName, err)
+		return
+	}
+
+	targetID := odcUserID
+	if targetID == 0 {
+		accountName := cachedUsername
+		if accountName == "" {
+			accountName = sqlWorkbenchService.generateSqlWorkbenchUsername(dmsUserName)
+		}
+		odcUser, listErr := sqlWorkbenchService.findExactSqlWorkbenchUser(accountName, cookie)
+		if listErr != nil {
+			sqlWorkbenchService.log.Errorf("ODC disable skipped: list user %s failed: %v", accountName, listErr)
+			return
+		}
+		if odcUser == nil {
+			sqlWorkbenchService.log.Infof("ODC disable no-op: no unique user for %s", accountName)
+			return
+		}
+		targetID = odcUser.ID
+	}
+
+	if _, err := sqlWorkbenchService.client.SetUserEnabled(targetID, false, cookie); err != nil {
+		sqlWorkbenchService.log.Errorf("ODC disable failed for user id=%d (DMS user %s): %v", targetID, dmsUserName, err)
+		return
+	}
+	sqlWorkbenchService.log.Infof("ODC user id=%d disabled after DMS user %s delete", targetID, dmsUserName)
 }
 
 // validateODCSession 验证 ODC 会话是否有效


### PR DESCRIPTION
### **User description**
## 关联的 issue

https://github.com/actiontech/dms-ee/issues/948

## 描述你的变更

- 进台缓存未命中时先查后建 + 创建冲突再查绑定（策略 A），解除映射缺失与 ODC 同名残留死锁
- 删除 DMS 用户时清理 SqlWorkbench 缓存/会话，并对 ODC 对应用户禁用而非删除（策略 B）
- 客户端增补 ListUsers / SetUserEnabled / ResetUserPassword 与冲突错误识别

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

Made with [Cursor](https://cursor.com)


___

### **Description**
- 增强 DMS 与 ODC 用户同步自愈的双策略机制

- 策略 A：先查询再创建用户，处理创建冲突并绑定已存在用户

- 策略 B：删除 DMS 用户时清理 SqlWorkbench 缓存和会话，并对 ODC 用户禁用

- 新增 ODC 用户操作接口及错误处理，提升系统容错性


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DMS用户操作"] -->|登录/创建| B["策略 A：查询/创建/绑定"]
  A -->|删除用户| C["策略 B：清理缓存 & 禁用ODC用户"]
  B -- 成功绑定 --> D["保存SqlWorkbench用户缓存"]
  C -- 清理成功 --> E["更新会话/日志"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>router.go</strong><dd><code>注入并连接生命周期清理能力</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/apiserver/service/router.go

<ul><li>注入 SqlWorkbenchLifecycle 实例<br> <li> 连接 DMSController 与 SqlWorkbenchService 清理能力</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/657/files#diff-716d2fbe2c02d196d0887c546f1e9b3b0d15ab44c006685b8242c74f1c60078c">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_client.go</strong><dd><code>增强 ODC 用户接口与冲突错误处理</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/client/sql_workbench_client.go

<ul><li>新增 CreateUsersConflictError 错误类型及辅助函数<br> <li> 实现 ListUsers、SetUserEnabled、ResetUserPassword 接口<br> <li> 增强用户创建冲突处理逻辑（策略 A 补充）</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/657/files#diff-b38919bc9e67fca0f0ee36a1e881e48a3f75bec9f0abb1739ed4ba62b673d980">+294/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>重构用户创建、绑定及删除清理逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

<ul><li>重构 ensureSqlWorkbenchUser 以支持先查后创及冲突绑定<br> <li> 引入锁机制控制并发用户创建（lockEnsureSqlWorkbenchUser）<br> <li> 增加 ensureSqlWorkbenchUserUsable 方法确保用户可用性<br> <li> 实现 CleanupOnDMSUserDelete 清理策略 B 和 disableODCUserOnDMSDelete 方法</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/657/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+198/-16</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user.go</strong><dd><code>添加用户缓存清理及生命周期接口</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/biz/user.go

<ul><li>新增 DeleteSqlWorkbenchUserCache 接口<br> <li> 新增 DeleteSqlWorkbenchDatasourceCachesByUserID 方法<br> <li> 引入 SqlWorkbenchLifecycle 接口及注入方法<br> <li> 删除用户时调用清理 SqlWorkbench 缓存和禁用 ODC 用户</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/657/files#diff-e710bb748f07b03ac5394842bce0e55b1b8f2587a52493f44316105bc387cf6f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench.go</strong><dd><code>添加 SqlWorkbench 缓存删除方法</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/storage/sql_workbench.go

<ul><li>增加 DeleteSqlWorkbenchUserCache 方法<br> <li> 增加 DeleteSqlWorkbenchDatasourceCachesByUserID 方法<br> <li> 实现对缓存的删除操作，支持策略 B</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/657/files#diff-ac57760d655a642896d5c2a4e95d38e04a2c8d353fbc235d815c16c90626fc0c">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

