### PR TITLE
feat: sync GBase-8a datasource type and default schema to ODC

### DIFF
--- a/internal/dms/pkg/constant/const.go
+++ b/internal/dms/pkg/constant/const.go
@@ -264,6 +264,8 @@ func ParseDBType(s string) (DBType, error) {
 		return DBTypeOceanBaseOracle, nil
 	case "KingBase":
 		return DBTypeKingBase, nil
+	case "GBase-8a":
+		return DBTypeGBase8a, nil
 
 	default:
 		return "", fmt.Errorf("invalid db type: %s", s)

--- a/internal/dms/pkg/constant/const.go
+++ b/internal/dms/pkg/constant/const.go
@@ -262,6 +262,8 @@ func ParseDBType(s string) (DBType, error) {
 		return DBTypeRedis, nil
 	case "OceanBase For Oracle":
 		return DBTypeOceanBaseOracle, nil
+	case "KingBase":
+		return DBTypeKingBase, nil
 
 	default:
 		return "", fmt.Errorf("invalid db type: %s", s)
@@ -288,6 +290,7 @@ const (
 	DBTypeMongoDB         DBType = "MongoDB"
 	DBTypeRedis           DBType = "Redis"
 	DBTypeOceanBaseOracle DBType = "OceanBase For Oracle"
+	DBTypeKingBase        DBType = "KingBase"
 )
 
 var supportedDataExportDBTypes = map[DBType]struct{}{

--- a/internal/dms/pkg/constant/const.go
+++ b/internal/dms/pkg/constant/const.go
@@ -293,6 +293,7 @@ const (
 	DBTypeRedis           DBType = "Redis"
 	DBTypeOceanBaseOracle DBType = "OceanBase For Oracle"
 	DBTypeKingBase        DBType = "KingBase"
+	DBTypeGBase8a         DBType = "GBase-8a"
 )
 
 var supportedDataExportDBTypes = map[DBType]struct{}{

--- a/internal/dms/pkg/constant/const_test.go
+++ b/internal/dms/pkg/constant/const_test.go
@@ -130,6 +130,7 @@ func TestParseDBType(t *testing.T) {
 		"MongoDB":           {input: "MongoDB", expected: DBTypeMongoDB},
 		"Redis":             {input: "Redis", expected: DBTypeRedis},
 		"KingBase":          {input: "KingBase", expected: DBTypeKingBase},
+		"GBase-8a":          {input: "GBase-8a", expected: DBTypeGBase8a},
 		// "PolarDB" 单独不应匹配
 		"PolarDB only": {input: "PolarDB", expectError: true},
 		"invalid type": {input: "UnknownDB", expectError: true},

--- a/internal/dms/pkg/constant/const_test.go
+++ b/internal/dms/pkg/constant/const_test.go
@@ -129,6 +129,7 @@ func TestParseDBType(t *testing.T) {
 		"PolarDB For MySQL": {input: "PolarDB For MySQL", expected: DBTypePolarDBForMySQL},
 		"MongoDB":           {input: "MongoDB", expected: DBTypeMongoDB},
 		"Redis":             {input: "Redis", expected: DBTypeRedis},
+		"KingBase":          {input: "KingBase", expected: DBTypeKingBase},
 		// "PolarDB" 单独不应匹配
 		"PolarDB only": {input: "PolarDB", expectError: true},
 		"invalid type": {input: "UnknownDB", expectError: true},

--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -1047,6 +1047,13 @@ const (
 	mongoAuthDatabaseParam    = "auth_source"
 	mongoReplicaSetParam      = "replica_set"
 	redisDefaultDatabaseParam = "default_database"
+
+	// GBase-8a：DMS 附加参数 → ODC 字段
+	gbase8aDatabaseParam     = "database"
+	gbase8aVcNameParam       = "vc_name"
+	gbase8aVcNameParamAlias  = "vcName"
+	gbase8aJdbcVcNameKey     = "vcName"
+	gbase8aDefaultSessionVC  = "vc1" // 与 DSN / session_vc 对齐；表单暂未暴露 VC 时的会话硬门槛缺省
 )
 
 // buildDatasourceBaseInfo 构建数据源基础信息
@@ -1106,7 +1113,32 @@ func (sqlWorkbenchService *SqlWorkbenchService) fillDatasourceBaseInfo(datasourc
 		baseInfo.DefaultSchema = &databaseName
 	}
 
+	// GBase-8a：AdditionalParams.database → DefaultSchema；VC → jdbcUrlParameters.vcName
+	if dbService.DBType == string(pkgConst.DBTypeGBase8a) {
+		databaseParam := dbService.AdditionalParams.GetParam(gbase8aDatabaseParam)
+		if databaseParam == nil || databaseParam.Value == "" {
+			return nil, fmt.Errorf("GBase-8a 数据源 %s 缺少 AdditionalParam database，请在数据源 AdditionalParams 中补充", dbService.Name)
+		}
+		database := databaseParam.Value
+		baseInfo.DefaultSchema = &database
+		baseInfo.JDBCParams = buildGBase8aJdbcUrlParameters(dbService)
+	}
+
 	return baseInfo, nil
+}
+
+// buildGBase8aJdbcUrlParameters 将会话 VC 写入 ODC jdbcUrlParameters（键 vcName）。
+// 优先 AdditionalParams.vc_name / vcName；缺省注入 vc1（S2 会话硬门槛；插件 metas 暂仅暴露 database）。
+func buildGBase8aJdbcUrlParameters(dbService *biz.DBService) map[string]interface{} {
+	vcName := gbase8aDefaultSessionVC
+	if p := dbService.AdditionalParams.GetParam(gbase8aVcNameParam); p != nil && p.Value != "" {
+		vcName = p.Value
+	} else if p := dbService.AdditionalParams.GetParam(gbase8aVcNameParamAlias); p != nil && p.Value != "" {
+		vcName = p.Value
+	}
+	return map[string]interface{}{
+		gbase8aJdbcVcNameKey: vcName,
+	}
 }
 
 // buildCreateDatasourceRequest 构建创建数据源请求
@@ -1199,6 +1231,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) convertDBType(dmsDBType string) 
 		return "DB2"
 	case "KingBase":
 		return "KINGBASE"
+	case "GBase-8a":
+		return "GBASE_8A"
 	default:
 		return dmsDBType
 	}
@@ -1216,7 +1250,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) SupportDBType(dbType pkgConst.DB
 		dbType == pkgConst.DBTypeGaussDB ||
 		dbType == pkgConst.DBTypePostgreSQL ||
 		dbType == pkgConst.DBTypeRedis ||
-		dbType == pkgConst.DBTypeKingBase
+		dbType == pkgConst.DBTypeKingBase ||
+		dbType == pkgConst.DBTypeGBase8a
 }
 
 func buildMongoDatasourceOptions(dbService *biz.DBService) (*string, interface{}, map[string]interface{}) {

--- a/internal/sql_workbench/service/sql_workbench_service.go
+++ b/internal/sql_workbench/service/sql_workbench_service.go
@@ -1096,6 +1096,16 @@ func (sqlWorkbenchService *SqlWorkbenchService) fillDatasourceBaseInfo(datasourc
 		baseInfo.DefaultSchema = &databaseName
 	}
 
+	// KingBase：database_name → ODC defaultSchema；缺失则失败，禁止静默空默认库
+	if dbService.DBType == string(pkgConst.DBTypeKingBase) {
+		databaseNameParam := dbService.AdditionalParams.GetParam("database_name")
+		if databaseNameParam == nil || databaseNameParam.Value == "" {
+			return nil, fmt.Errorf("KingBase 数据源 %s 缺少 AdditionalParam database_name，请在数据源 AdditionalParams 中补充", dbService.Name)
+		}
+		databaseName := databaseNameParam.Value
+		baseInfo.DefaultSchema = &databaseName
+	}
+
 	return baseInfo, nil
 }
 
@@ -1187,6 +1197,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) convertDBType(dmsDBType string) 
 		return "REDIS"
 	case "DB2":
 		return "DB2"
+	case "KingBase":
+		return "KINGBASE"
 	default:
 		return dmsDBType
 	}
@@ -1203,7 +1215,8 @@ func (sqlWorkbenchService *SqlWorkbenchService) SupportDBType(dbType pkgConst.DB
 		dbType == pkgConst.DBTypePolarDBForMySQL ||
 		dbType == pkgConst.DBTypeGaussDB ||
 		dbType == pkgConst.DBTypePostgreSQL ||
-		dbType == pkgConst.DBTypeRedis
+		dbType == pkgConst.DBTypeRedis ||
+		dbType == pkgConst.DBTypeKingBase
 }
 
 func buildMongoDatasourceOptions(dbService *biz.DBService) (*string, interface{}, map[string]interface{}) {

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -151,6 +151,7 @@ func Test_convertDBType(t *testing.T) {
 		"Redis":               {input: "Redis", expected: "REDIS"},
 		"DB2":                 {input: "DB2", expected: "DB2"},
 		"KingBase":            {input: "KingBase", expected: "KINGBASE"},
+		"GBase-8a":            {input: "GBase-8a", expected: "GBASE_8A"},
 		"Unknown passthrough": {input: "UnknownDB", expected: "UnknownDB"},
 	}
 	for name, tc := range cases {
@@ -185,6 +186,7 @@ func Test_SupportDBType(t *testing.T) {
 		"GaussDBForMySQL unsupported": {input: pkgConst.DBTypeGaussDBForMySQL, expected: false},
 		"DB2 unsupported":             {input: pkgConst.DBTypeDB2, expected: false},
 		"KingBase supported":          {input: pkgConst.DBTypeKingBase, expected: true},
+		"GBase-8a supported":          {input: pkgConst.DBTypeGBase8a, expected: true},
 		"empty string unsupported":    {input: pkgConst.DBType(""), expected: false},
 		"unknown type unsupported":    {input: pkgConst.DBType("UnknownDBType"), expected: false},
 	}
@@ -312,6 +314,7 @@ func Test_buildDatasourceBaseInfo_DB2(t *testing.T) {
 		expectErrSubstr     string
 		expectDefaultSchema *string
 		expectServiceName   *string
+		expectJdbcVcName    *string // nil = 不要求 JDBCParams；非 nil = 断言 jdbcUrlParameters.vcName
 	}{
 		"DB2 happy path": {
 			dbService: &biz.DBService{
@@ -356,6 +359,53 @@ func Test_buildDatasourceBaseInfo_DB2(t *testing.T) {
 			expectDefaultSchema: nil,
 			expectServiceName:   strPtr("ORCL"),
 		},
+		"GBase-8a happy path defaults vc1": {
+			dbService: &biz.DBService{
+				Name:   "gbase8a-1",
+				DBType: string(pkgConst.DBTypeGBase8a),
+				AdditionalParams: pkgParams.Params{
+					{Key: "database", Value: "gbase"},
+				},
+			},
+			expectErr:           false,
+			expectDefaultSchema: strPtr("gbase"),
+			expectServiceName:   nil,
+			expectJdbcVcName:    strPtr("vc1"),
+		},
+		"GBase-8a vc_name override": {
+			dbService: &biz.DBService{
+				Name:   "gbase8a-vc",
+				DBType: string(pkgConst.DBTypeGBase8a),
+				AdditionalParams: pkgParams.Params{
+					{Key: "database", Value: "gbase"},
+					{Key: "vc_name", Value: "vc_custom"},
+				},
+			},
+			expectErr:           false,
+			expectDefaultSchema: strPtr("gbase"),
+			expectServiceName:   nil,
+			expectJdbcVcName:    strPtr("vc_custom"),
+		},
+		"GBase-8a missing database": {
+			dbService: &biz.DBService{
+				Name:             "gbase8a-2",
+				DBType:           string(pkgConst.DBTypeGBase8a),
+				AdditionalParams: pkgParams.Params{},
+			},
+			expectErr:       true,
+			expectErrSubstr: "database",
+		},
+		"GBase-8a ignores database_name": {
+			dbService: &biz.DBService{
+				Name:   "gbase8a-3",
+				DBType: string(pkgConst.DBTypeGBase8a),
+				AdditionalParams: pkgParams.Params{
+					{Key: "database_name", Value: "wrong"},
+				},
+			},
+			expectErr:       true,
+			expectErrSubstr: "database",
+		},
 	}
 
 	for name, tc := range cases {
@@ -387,6 +437,15 @@ func Test_buildDatasourceBaseInfo_DB2(t *testing.T) {
 				t.Errorf("ServiceName nil mismatch: got=%v, want=%v", got.ServiceName, tc.expectServiceName)
 			} else if got.ServiceName != nil && tc.expectServiceName != nil && *got.ServiceName != *tc.expectServiceName {
 				t.Errorf("ServiceName = %q, want %q", *got.ServiceName, *tc.expectServiceName)
+			}
+			if tc.expectJdbcVcName != nil {
+				if got.JDBCParams == nil {
+					t.Fatalf("expected JDBCParams with vcName=%q, got nil", *tc.expectJdbcVcName)
+				}
+				gotVC, _ := got.JDBCParams[gbase8aJdbcVcNameKey].(string)
+				if gotVC != *tc.expectJdbcVcName {
+					t.Errorf("JDBCParams.vcName = %q, want %q; params=%v", gotVC, *tc.expectJdbcVcName, got.JDBCParams)
+				}
 			}
 		})
 	}

--- a/internal/sql_workbench/service/sql_workbench_service_test.go
+++ b/internal/sql_workbench/service/sql_workbench_service_test.go
@@ -150,6 +150,7 @@ func Test_convertDBType(t *testing.T) {
 		"MongoDB":             {input: "MongoDB", expected: "MONGODB"},
 		"Redis":               {input: "Redis", expected: "REDIS"},
 		"DB2":                 {input: "DB2", expected: "DB2"},
+		"KingBase":            {input: "KingBase", expected: "KINGBASE"},
 		"Unknown passthrough": {input: "UnknownDB", expected: "UnknownDB"},
 	}
 	for name, tc := range cases {
@@ -183,6 +184,7 @@ func Test_SupportDBType(t *testing.T) {
 		"GaussDB supported":           {input: pkgConst.DBTypeGaussDB, expected: true},
 		"GaussDBForMySQL unsupported": {input: pkgConst.DBTypeGaussDBForMySQL, expected: false},
 		"DB2 unsupported":             {input: pkgConst.DBTypeDB2, expected: false},
+		"KingBase supported":          {input: pkgConst.DBTypeKingBase, expected: true},
 		"empty string unsupported":    {input: pkgConst.DBType(""), expected: false},
 		"unknown type unsupported":    {input: pkgConst.DBType("UnknownDBType"), expected: false},
 	}
@@ -385,6 +387,89 @@ func Test_buildDatasourceBaseInfo_DB2(t *testing.T) {
 				t.Errorf("ServiceName nil mismatch: got=%v, want=%v", got.ServiceName, tc.expectServiceName)
 			} else if got.ServiceName != nil && tc.expectServiceName != nil && *got.ServiceName != *tc.expectServiceName {
 				t.Errorf("ServiceName = %q, want %q", *got.ServiceName, *tc.expectServiceName)
+			}
+		})
+	}
+}
+
+// Test_buildDatasourceBaseInfo_KingBase 覆盖 KingBase → defaultSchema 契约（S1 / AC-1）：
+//
+//	(a) 正例：database_name=test → DefaultSchema=="test" 且 Type 经 convert 为 KINGBASE
+//	(b) 负例：缺 database_name → err 含 "database_name"
+//	(c) MySQL 回归：DefaultSchema == nil
+func Test_buildDatasourceBaseInfo_KingBase(t *testing.T) {
+	svc := &SqlWorkbenchService{}
+	const envID = int64(1)
+	const datasourceName = "proj:kingbase_odc_test"
+
+	cases := map[string]struct {
+		dbService           *biz.DBService
+		expectErr           bool
+		expectErrSubstr     string
+		expectDefaultSchema *string
+		expectType          string
+	}{
+		"KingBase happy path": {
+			dbService: &biz.DBService{
+				Name:   "kingbase_odc_test",
+				DBType: string(pkgConst.DBTypeKingBase),
+				Host:   "10.186.16.126",
+				Port:   "1522",
+				User:   "kb_dev",
+				AdditionalParams: pkgParams.Params{
+					{Key: "database_name", Value: "test"},
+				},
+			},
+			expectErr:           false,
+			expectDefaultSchema: strPtr("test"),
+			expectType:          "KINGBASE",
+		},
+		"KingBase missing database_name": {
+			dbService: &biz.DBService{
+				Name:             "kingbase-missing-db",
+				DBType:           string(pkgConst.DBTypeKingBase),
+				AdditionalParams: pkgParams.Params{},
+			},
+			expectErr:       true,
+			expectErrSubstr: "database_name",
+		},
+		"MySQL regression still no DefaultSchema": {
+			dbService: &biz.DBService{
+				Name:             "mysql-1",
+				DBType:           "MySQL",
+				AdditionalParams: pkgParams.Params{},
+			},
+			expectErr:           false,
+			expectDefaultSchema: nil,
+			expectType:          "MYSQL",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := svc.fillDatasourceBaseInfo(datasourceName, tc.dbService, envID)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil; baseInfo=%+v", got)
+				}
+				if tc.expectErrSubstr != "" && !strings.Contains(err.Error(), tc.expectErrSubstr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.expectErrSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil baseInfo")
+			}
+			if tc.expectType != "" && got.Type != tc.expectType {
+				t.Errorf("Type = %q, want %q", got.Type, tc.expectType)
+			}
+			if (got.DefaultSchema == nil) != (tc.expectDefaultSchema == nil) {
+				t.Errorf("DefaultSchema nil mismatch: got=%v, want=%v", got.DefaultSchema, tc.expectDefaultSchema)
+			} else if got.DefaultSchema != nil && tc.expectDefaultSchema != nil && *got.DefaultSchema != *tc.expectDefaultSchema {
+				t.Errorf("DefaultSchema = %q, want %q", *got.DefaultSchema, *tc.expectDefaultSchema)
 			}
 		})
 	}


### PR DESCRIPTION
### **User description**
## 关联的 issue

https://github.com/actiontech/dms-ee/issues/965

## 描述你的变更

- CE 共享面增加 `DBTypeGBase8a` / ParseDBType
- sql_workbench：`GBase-8a`→`GBASE_8A`；`database`→DefaultSchema；VC→`jdbcUrlParameters.vcName`（缺省 vc1）
- 已 rebase 金仓特性分支 `feat-964-odc-kingbase`；与 KingBase 映射并存（非 `_ee` 文件走 CE PR，对齐 check-pr-files）

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [x] 我已记录完整日志方便进行诊断
- [x] 我已在关联的issue里补充了实现方案
- [x] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------

Made with [Cursor](https://cursor.com)


___

### **Description**
- 增加 KingBase 数据源类型解析及常量定义

- 为 GBase-8a 数据源设置默认 Schema 且构建 JDBC 参数

- 修改 SQL Workbench 服务逻辑以支持新数据源类型

- 添加完善相关测试用例以验证新功能


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["更新常量定义文件"]
  B["扩展 ParseDBType 函数"]
  C["调整 SQL Workbench 逻辑"]
  D["添加测试用例覆盖"]
  A -- "新增 KingBase 与 GBase8a 常量" --> B
  B -- "解析新数据源类型" --> C
  C -- "设置 DefaultSchema 与 JDBC 参数" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>const.go</strong><dd><code>修改数据源类型解析与常量定义</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/pkg/constant/const.go

- 新增对 "KingBase" 与 "GBase-8a" 的类型解析
- 添加对应的常量定义


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/667/files#diff-f73102f4630133e7d63ff7bd39086da745907c9ced4ee43b64c48b5260dabcd9">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service.go</strong><dd><code>增加 SQL Workbench 新数据源支持逻辑</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service.go

<ul><li>为 KingBase 设置 database_name 作为 DefaultSchema<br> <li> 为 GBase-8a 从 AdditionalParams 构建 JDBC 参数 (vcName)<br> <li> 更新 convertDBType 函数返回新类型映射</ul>


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/667/files#diff-68e077b9a4555223ade9ea55f6d9c6ea84c06cb60940ab7fbcb6dc2be0335cf7">+49/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>const_test.go</strong><dd><code>增加数据源类型解析测试</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/dms/pkg/constant/const_test.go

- 添加 KingBase 与 GBase-8a 的测试用例
- 扩展类型解析测试覆盖


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/667/files#diff-e67cb9f0b424e5b03022b451cc7b8a4fa7828c8446596ece9df84b7355385029">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sql_workbench_service_test.go</strong><dd><code>添加新数据源支持测试用例</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

internal/sql_workbench/service/sql_workbench_service_test.go

- 新增 KingBase 数据源相关测试
- 增加 GBase-8a 默认 Schema 与 JDBC 参数验证


</details>


  </td>
  <td><a href="https://github.com/actiontech/dms/pull/667/files#diff-f1262957293a3a114d62c6c25384b4b6ff3429052ff38b2ea648d687f79fdb08">+144/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

